### PR TITLE
openshift-3.11: use version vars for cluster-monitoring-operator

### DIFF
--- a/openshift-3.11/group.yml
+++ b/openshift-3.11/group.yml
@@ -220,7 +220,7 @@ sources:
   cluster-monitoring-operator:
     url: git@github.com:openshift/cluster-monitoring-operator.git
     branch:
-      target: release-3.11
+      target: release-{MAJOR}.{MINOR}
   grafana:
     url: git@github.com:openshift/grafana.git
     branch:


### PR DESCRIPTION
AFAICT it should be ok to use the version variables here instead of the hard-coded version.  The hard-coded version was introduced in a previous commit (9a31c6b655fb97a915a53368370240b4f001650e) to prevent building from master.
