### PR TITLE
Update ose-metering-helm Dockerfile source

### DIFF
--- a/openshift-4.0/group.yml
+++ b/openshift-4.0/group.yml
@@ -289,7 +289,7 @@ sources:
     url: git@github.com:operator-framework/helm.git
     branch:
       target: release-{MAJOR}.{MINOR}
-      fallback: master
+      fallback: metering-master
 
   cluster-node-tuning-operator:
     url: git@github.com:openshift/cluster-node-tuning-operator.git

--- a/openshift-4.0/images/ose-metering-helm.yml
+++ b/openshift-4.0/images/ose-metering-helm.yml
@@ -7,6 +7,7 @@ owners:
 content:
   source:
     alias: helm
+    dockerfile: Dockerfile.rhel
 
 from:
   builder:


### PR DESCRIPTION
There is now a rhel specific Dockerfile for helm: https://github.com/operator-framework/helm/blob/release-4.0/Dockerfile.rhel