### PR TITLE
Update reporting operator Dockerfile source

### DIFF
--- a/openshift-4.0/images/ose-metering-reporting-operator.yml
+++ b/openshift-4.0/images/ose-metering-reporting-operator.yml
@@ -7,11 +7,9 @@ owners:
 content:
   source:
     alias: operator-metering
-    dockerfile: Dockerfile.reporting-operator
+    dockerfile: Dockerfile.reporting-operator.rhel
 
 from:
   builder:
   - image: openshift/golang-builder:1.10
   member: openshift-enterprise-base
-
-  


### PR DESCRIPTION
There is now a rhel specific Dockerfile for ose-metering-reporting-operator: https://github.com/operator-framework/operator-metering/blob/master/Dockerfile.reporting-operator.rhel