### PR TITLE
3.10: put puddle repo name back

### DIFF
--- a/openshift-3.10/group.yml
+++ b/openshift-3.10/group.yml
@@ -28,21 +28,21 @@ repos:
   rhel-server-ose-rpms:
     conf:
       baseurl:
-        x86_64: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/ose/{MAJOR}.{MINOR}/os/
-        ppc64le: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/power-le/7/7Server/ppc64le/ose/{MAJOR}.{MINOR}/os
-    content_set:
-      optional: true
-      default: rhel-7-server-ose-{MAJOR}.{MINOR}-rpms
-      ppc64le: rhel-7-for-power-le-ose-{MAJOR}.{MINOR}-rpms
-  rhel-server-ose-puddle:
-    conf:
-      baseurl:
         signed:
           x86_64: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/AtomicOpenShift-signed/{MAJOR}.{MINOR}/building/RH7-RHAOS-{MAJOR}.{MINOR}/x86_64/os
           ppc64le: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/AtomicOpenShift-signed/{MAJOR}.{MINOR}/building/RH7-RHAOS-{MAJOR}.{MINOR}/ppc64le/os
         unsigned:
           x86_64: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/AtomicOpenShift/{MAJOR}.{MINOR}/building/x86_64/os
           ppc64le: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/AtomicOpenShift/{MAJOR}.{MINOR}/building/ppc64le/os
+    content_set:
+      optional: true
+      default: rhel-7-server-ose-{MAJOR}.{MINOR}-rpms
+      ppc64le: rhel-7-for-power-le-ose-{MAJOR}.{MINOR}-rpms
+  rhel-server-ose-rpms-shipped:
+    conf:
+      baseurl:
+        x86_64: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/ose/{MAJOR}.{MINOR}/os/
+        ppc64le: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/power-le/7/7Server/ppc64le/ose/{MAJOR}.{MINOR}/os
     content_set:
       optional: true
       default: rhel-7-server-ose-{MAJOR}.{MINOR}-rpms

--- a/openshift-3.10/images/aos3-installation.yml
+++ b/openshift-3.10/images/aos3-installation.yml
@@ -5,7 +5,7 @@ content:
     path: images/installer
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 - rhel-server-extras-rpms
 - rhel-7-server-ansible-2.4-rpms
 from:

--- a/openshift-3.10/images/atomic-openshift-descheduler.yml
+++ b/openshift-3.10/images/atomic-openshift-descheduler.yml
@@ -4,7 +4,7 @@ content:
     path: images/descheduler
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   stream: rhel
 labels:

--- a/openshift-3.10/images/atomic-openshift-node-problem-detector.yml
+++ b/openshift-3.10/images/atomic-openshift-node-problem-detector.yml
@@ -4,7 +4,7 @@ content:
     path: images
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   stream: rhel
 labels:

--- a/openshift-3.10/images/csi-attacher.yml
+++ b/openshift-3.10/images/csi-attacher.yml
@@ -1,6 +1,6 @@
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   stream: rhel
 labels:

--- a/openshift-3.10/images/csi-driver-registrar.yml
+++ b/openshift-3.10/images/csi-driver-registrar.yml
@@ -1,6 +1,6 @@
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   stream: rhel
 labels:

--- a/openshift-3.10/images/csi-livenessprobe.yml
+++ b/openshift-3.10/images/csi-livenessprobe.yml
@@ -1,6 +1,6 @@
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   stream: rhel
 labels:

--- a/openshift-3.10/images/csi-provisioner.yml
+++ b/openshift-3.10/images/csi-provisioner.yml
@@ -1,6 +1,6 @@
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   stream: rhel
 labels:

--- a/openshift-3.10/images/efs-provisioner.yml
+++ b/openshift-3.10/images/efs-provisioner.yml
@@ -4,7 +4,7 @@ owners: [ 'aos-storage-staff@redhat.com' ]
 
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 
 from:
   stream: rhel

--- a/openshift-3.10/images/golang-github-openshift-oauth-proxy.yml
+++ b/openshift-3.10/images/golang-github-openshift-oauth-proxy.yml
@@ -1,6 +1,6 @@
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   stream: rhel
 labels:

--- a/openshift-3.10/images/golang-github-openshift-prometheus-alert-buffer.yml
+++ b/openshift-3.10/images/golang-github-openshift-prometheus-alert-buffer.yml
@@ -1,6 +1,6 @@
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   stream: rhel
 labels:

--- a/openshift-3.10/images/golang-github-prometheus-alertmanager.yml
+++ b/openshift-3.10/images/golang-github-prometheus-alertmanager.yml
@@ -1,6 +1,6 @@
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   stream: rhel
 labels:

--- a/openshift-3.10/images/golang-github-prometheus-node_exporter.yml
+++ b/openshift-3.10/images/golang-github-prometheus-node_exporter.yml
@@ -4,7 +4,7 @@ content:
     dockerfile: Dockerfile.rhel7
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   stream: rhel
 labels:

--- a/openshift-3.10/images/golang-github-prometheus-prometheus.yml
+++ b/openshift-3.10/images/golang-github-prometheus-prometheus.yml
@@ -1,6 +1,6 @@
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   stream: rhel
 labels:

--- a/openshift-3.10/images/image-inspector.yml
+++ b/openshift-3.10/images/image-inspector.yml
@@ -1,6 +1,6 @@
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   stream: rhel
 labels:

--- a/openshift-3.10/images/jenkins-agent-nodejs-8-rhel7.yml
+++ b/openshift-3.10/images/jenkins-agent-nodejs-8-rhel7.yml
@@ -19,6 +19,6 @@ owners:
 - bparees@redhat.com
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 - rhel-server-optional-rpms
 - rhel-server-rhscl-rpms

--- a/openshift-3.10/images/logging-auth-proxy.yml
+++ b/openshift-3.10/images/logging-auth-proxy.yml
@@ -1,6 +1,6 @@
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 - rhel-server-ose-OLD_NODE_JS-rpms
 from:
   stream: rhel

--- a/openshift-3.10/images/logging-curator.yml
+++ b/openshift-3.10/images/logging-curator.yml
@@ -7,7 +7,7 @@ from:
     stream: rhel
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 - rhel-server-extras-rpms
 labels:
   License: GPLv2+

--- a/openshift-3.10/images/logging-elasticsearch.yml
+++ b/openshift-3.10/images/logging-elasticsearch.yml
@@ -11,7 +11,7 @@ from:
     stream: rhel
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 - rhel-server-extras-rpms
 labels:
   License: GPLv2+

--- a/openshift-3.10/images/logging-eventrouter.yml
+++ b/openshift-3.10/images/logging-eventrouter.yml
@@ -1,6 +1,6 @@
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 - rhel-server-extras-rpms
 from:
   stream: rhel

--- a/openshift-3.10/images/logging-fluentd.yml
+++ b/openshift-3.10/images/logging-fluentd.yml
@@ -7,7 +7,7 @@ from:
     stream: rhel
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 labels:
   License: GPLv2+
   architecture: x86_64

--- a/openshift-3.10/images/logging-kibana.yml
+++ b/openshift-3.10/images/logging-kibana.yml
@@ -5,7 +5,7 @@ content:
     path: kibana
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   image: rhscl/nodejs-6-rhel7
 labels:

--- a/openshift-3.10/images/metrics-hawkular-openshift-agent.yml
+++ b/openshift-3.10/images/metrics-hawkular-openshift-agent.yml
@@ -1,6 +1,6 @@
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   stream: rhel
 labels:

--- a/openshift-3.10/images/metrics-heapster.yml
+++ b/openshift-3.10/images/metrics-heapster.yml
@@ -1,6 +1,6 @@
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   stream: rhel
 labels:

--- a/openshift-3.10/images/openshift-enterprise-apb-base.yml
+++ b/openshift-3.10/images/openshift-enterprise-apb-base.yml
@@ -1,6 +1,6 @@
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 - rhel-server-extras-rpms
 - rhel-server-optional-rpms
 - rhel-7-server-ansible-2.5-rpms

--- a/openshift-3.10/images/openshift-enterprise-apb.yml
+++ b/openshift-3.10/images/openshift-enterprise-apb.yml
@@ -1,6 +1,6 @@
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 - rhel-server-extras-rpms
 - rhel-server-optional-rpms
 from:

--- a/openshift-3.10/images/openshift-enterprise-asb.yml
+++ b/openshift-3.10/images/openshift-enterprise-asb.yml
@@ -1,6 +1,6 @@
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   stream: rhel
 labels:

--- a/openshift-3.10/images/openshift-enterprise-cli.yml
+++ b/openshift-3.10/images/openshift-enterprise-cli.yml
@@ -8,7 +8,7 @@ content:
     path: images/cli
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   member: openshift-enterprise-base
 labels:

--- a/openshift-3.10/images/openshift-enterprise-cluster-capacity.yml
+++ b/openshift-3.10/images/openshift-enterprise-cluster-capacity.yml
@@ -21,4 +21,4 @@ owners:
   - avagarwa@redhat.com
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped

--- a/openshift-3.10/images/openshift-enterprise-egress-dns-proxy.yml
+++ b/openshift-3.10/images/openshift-enterprise-egress-dns-proxy.yml
@@ -18,4 +18,4 @@ distgit:
   component: openshift-enterprise-egress-dns-proxy-container
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped

--- a/openshift-3.10/images/openshift-enterprise-haproxy-router.yml
+++ b/openshift-3.10/images/openshift-enterprise-haproxy-router.yml
@@ -24,4 +24,4 @@ name: openshift3/ose-haproxy-router
 owners: []
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped

--- a/openshift-3.10/images/openshift-enterprise-hyperkube.yml
+++ b/openshift-3.10/images/openshift-enterprise-hyperkube.yml
@@ -8,7 +8,7 @@ content:
     path: images/hyperkube
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   member: openshift-enterprise-base
 labels:

--- a/openshift-3.10/images/openshift-enterprise-hypershift.yml
+++ b/openshift-3.10/images/openshift-enterprise-hypershift.yml
@@ -8,7 +8,7 @@ content:
     path: images/hypershift
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   member: openshift-enterprise-base
 labels:

--- a/openshift-3.10/images/openshift-enterprise-mariadb.yml
+++ b/openshift-3.10/images/openshift-enterprise-mariadb.yml
@@ -2,7 +2,7 @@ distgit:
   namespace: apbs
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   member: openshift-enterprise-apb-base
 labels:

--- a/openshift-3.10/images/openshift-enterprise-mediawiki.apb.yml
+++ b/openshift-3.10/images/openshift-enterprise-mediawiki.apb.yml
@@ -2,7 +2,7 @@ distgit:
   namespace: apbs
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   member: openshift-enterprise-apb-base
 

--- a/openshift-3.10/images/openshift-enterprise-mediawiki.container.yml
+++ b/openshift-3.10/images/openshift-enterprise-mediawiki.container.yml
@@ -1,6 +1,6 @@
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 - rhel-server-rhscl-rpms
 from:
   stream: rhel

--- a/openshift-3.10/images/openshift-enterprise-mysql.yml
+++ b/openshift-3.10/images/openshift-enterprise-mysql.yml
@@ -2,7 +2,7 @@ distgit:
   namespace: apbs
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   member: openshift-enterprise-apb-base
 labels:

--- a/openshift-3.10/images/openshift-enterprise-node.yml
+++ b/openshift-3.10/images/openshift-enterprise-node.yml
@@ -30,7 +30,7 @@ content:
     path: images/node
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 - rhel-fast-datapath-rpms
 - rhel-server-extras-rpms
 from:

--- a/openshift-3.10/images/openshift-enterprise-pod.yml
+++ b/openshift-3.10/images/openshift-enterprise-pod.yml
@@ -13,7 +13,7 @@ content:
     path: images/pod
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   stream: rhel
 labels:

--- a/openshift-3.10/images/openshift-enterprise-postgresql.yml
+++ b/openshift-3.10/images/openshift-enterprise-postgresql.yml
@@ -2,7 +2,7 @@ distgit:
   namespace: apbs
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   member: openshift-enterprise-apb-base
 labels:

--- a/openshift-3.10/images/openshift-enterprise-registry.yml
+++ b/openshift-3.10/images/openshift-enterprise-registry.yml
@@ -8,7 +8,7 @@ content:
     path: images/dockerregistry
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   member: openshift-enterprise-base
 labels:

--- a/openshift-3.10/images/openshift-enterprise-service-catalog.yml
+++ b/openshift-3.10/images/openshift-enterprise-service-catalog.yml
@@ -8,7 +8,7 @@ content:
       replacement: atomic-enterprise-service-catalog
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   member: openshift-enterprise-base
 labels:

--- a/openshift-3.10/images/openshift-enterprise.yml
+++ b/openshift-3.10/images/openshift-enterprise.yml
@@ -14,7 +14,7 @@ content:
     path: images/origin
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 - rhel-7-server-rhceph-3-tools-rpms
 from:
   member: openshift-enterprise-base

--- a/openshift-3.10/images/openshift-jenkins-2.yml
+++ b/openshift-3.10/images/openshift-jenkins-2.yml
@@ -5,7 +5,7 @@ content:
     path: '2'
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   member: openshift-enterprise
 labels:

--- a/openshift-3.10/images/openshift-local-storage.yml
+++ b/openshift-3.10/images/openshift-local-storage.yml
@@ -1,6 +1,6 @@
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   stream: rhel
 labels:

--- a/openshift-3.10/images/openshift-manila-provisioner.yml
+++ b/openshift-3.10/images/openshift-manila-provisioner.yml
@@ -1,6 +1,6 @@
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   stream: rhel
 labels:

--- a/openshift-3.10/images/openshift-monitor-project-lifecycle.yml
+++ b/openshift-3.10/images/openshift-monitor-project-lifecycle.yml
@@ -15,4 +15,4 @@ name: openshift3/ose-monitor-project-lifecycle
 owners: []
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped

--- a/openshift-3.10/images/openshift-monitor-sample-app.yml
+++ b/openshift-3.10/images/openshift-monitor-sample-app.yml
@@ -19,4 +19,4 @@ name: openshift3/monitor-sample-app
 owners: []
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped

--- a/openshift-3.10/images/origin-web-console-server.yml
+++ b/openshift-3.10/images/origin-web-console-server.yml
@@ -8,7 +8,7 @@ content:
     path: images/origin-web-console
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   member: openshift-enterprise-base
 labels:

--- a/openshift-3.10/images/registry-console.yml
+++ b/openshift-3.10/images/registry-console.yml
@@ -1,6 +1,6 @@
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 - rhel-server-extras-rpms
 from:
   stream: rhel

--- a/openshift-3.10/images/snapshot-controller.yml
+++ b/openshift-3.10/images/snapshot-controller.yml
@@ -1,6 +1,6 @@
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   stream: rhel
 labels:

--- a/openshift-3.10/images/snapshot-provisioner.yml
+++ b/openshift-3.10/images/snapshot-provisioner.yml
@@ -1,6 +1,6 @@
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   stream: rhel
 labels:

--- a/openshift-3.10/images/template-service-broker.yml
+++ b/openshift-3.10/images/template-service-broker.yml
@@ -9,7 +9,7 @@ content:
     path: images/template-service-broker
 enabled_repos:
 - rhel-server-ose-rpms
-- rhel-server-ose-puddle
+- rhel-server-ose-rpms-shipped
 from:
   stream: rhel
 labels:


### PR DESCRIPTION
It turns out that the ose-rpms repo is what oit looks at to determine
which version of the RPM is currently signed. So pointing that at
shipped content breaks things.

This commit puts that back the way it was and uses the ose-rpms-shipped
repo for the shipped RPMs.