### PR TITLE
update openshift/grafana repo to build from 'master'

### DIFF
--- a/openshift-3.11/group.yml
+++ b/openshift-3.11/group.yml
@@ -230,7 +230,7 @@ sources:
     url: git@github.com:openshift/grafana.git
     branch:
       target: release-{MAJOR}.{MINOR}
-      fallback: openshift-master
+      fallback: master
   oauth-proxy:
     url: git@github.com:openshift/oauth-proxy.git
     branch:

--- a/openshift-4.0/group.yml
+++ b/openshift-4.0/group.yml
@@ -229,7 +229,7 @@ sources:
     url: git@github.com:openshift/grafana.git
     branch:
       target: release-{MAJOR}.{MINOR}
-      fallback: openshift-master
+      fallback: master
   oauth-proxy:
     url: git@github.com:openshift/oauth-proxy.git
     branch:


### PR DESCRIPTION
The 'openshift-master' branch is now deprecated.