### PR TITLE
openshift-4.0: etcd

### DIFF
--- a/openshift-4.0/group.yml
+++ b/openshift-4.0/group.yml
@@ -352,10 +352,9 @@ sources:
       fallback: master
 
   etcd:
-    url: git@github.com:etcd-io/etcd.git
+    url: git@github.com:openshift/etcd.git
     branch:
-      target: release-{MAJOR}.{MINOR}
-      fallback: master
+      target: origin-{MAJOR}.{MINOR}-etcd-v3.3.10
 
   coredns:
     url: git@github.com:openshift/coredns.git

--- a/openshift-4.0/images/ose-etcd.yml
+++ b/openshift-4.0/images/ose-etcd.yml
@@ -7,14 +7,19 @@ owners:
 
 content:
   source:
-    alias: ose-etcd
+    alias: etcd
     dockerfile: Dockerfile.rhel
 
-# from:
-#   builder:
-#   -
+from:
+  builder:
+  - image: openshift/golang-builder:1.10
+  member: openshift-enterprise-base
 
+labels:
+  License: Apache 2.0
+  io.k8s.description: etcd is distributed key-value store which stores the
+    persistent master state for Kubernetes and OpenShift.
+  io.k8s.display-name: etcd server
+  io.openshift.tags: etcd
 
 mode: wip
-
-


### PR DESCRIPTION
* updated config to cover multi-stage build process
* added labels.
* updated etcd upstream and target

Dockerfile.rhel is located: https://github.com/openshift/etcd/tree/origin-4.0-etcd-v3.3.10