### PR TITLE
Correct image-inspector tags

### DIFF
--- a/openshift-3.7/images/image-inspector.yml
+++ b/openshift-3.7/images/image-inspector.yml
@@ -8,7 +8,3 @@ labels:
   vendor: Red Hat
 name: openshift3/image-inspector
 owners: []
-
-push:
-  additional_tags:
-    - '2.4'

--- a/openshift-3.9/images/image-inspector.yml
+++ b/openshift-3.9/images/image-inspector.yml
@@ -8,3 +8,7 @@ labels:
   vendor: Red Hat
 name: openshift3/image-inspector
 owners: []
+
+push:
+  additional_tags:
+    - '2.1'


### PR DESCRIPTION
Background: v3.* tags for image-inspector matching openshift versions are an accident of using openshift release pipeline; it's not consumed *as part of Openshift*, and has no separate versions per openshift release.
image-inspector has independent 2.* versioning.  It's consumed by Cloudforms which currently pulls 2.1 tag on *all versions of Openshift*.

This PR is for image-inspector 2.1.z that we're presently releasing from rpm on 3.9 channel: 
https://bugzilla.redhat.com/show_bug.cgi?id=1642039

The use of additional_tags for image-inspector 2.4 was started in
https://github.com/openshift/enterprise-images/commit/dc589a01acbd92da73b5b72ae9f4c3b1f9d20f76/#diff-e82d562d0ff7b956908e032665a888a2R14
However here I'm removing that 2.4, as we're discontinuing downstream 2.4.z builds — we plan for Cloudforms to stay on 2.1.z — and to reduce [customer confusion](https://bugzilla.redhat.com/show_bug.cgi?id=1620068#c78) even considering [removing existing 2.4 images](https://projects.engineering.redhat.com/browse/RCM-45362).

@jupierce @sosiouxme please review.  cc @nimrodshn 
