### PR TITLE
Multistage build for prometheus-operator images

### DIFF
--- a/openshift-4.0/images/prometheus-config-reloader.yml
+++ b/openshift-4.0/images/prometheus-config-reloader.yml
@@ -3,6 +3,8 @@ content:
     alias: prometheus-operator
     dockerfile: Dockerfile.config-reloader
 from:
+  builder:
+  - image: openshift/golang-builder:1.10
   member: openshift-enterprise-base
 labels:
   License: ASL 2.0

--- a/openshift-4.0/images/prometheus-operator.yml
+++ b/openshift-4.0/images/prometheus-operator.yml
@@ -4,6 +4,8 @@ content:
     dockerfile: Dockerfile
     path: ''
 from:
+  builder:
+  - image: openshift/golang-builder:1.10
   member: openshift-enterprise-base
 labels:
   License: ASL 2.0


### PR DESCRIPTION
openshift/prometheus-operator has recently switched to use multistage builds for OKD because it had a dependency on Go 1.10 (see https://github.com/openshift/prometheus-operator/pull/14). This is the corresponding change to ensure that the OCP builds keep running. It is based on the actual [cluster-monitoring-operator.yml](https://github.com/openshift/ocp-build-data/blob/7ddfe5bac449d02e9ea15a0c092f4b6fd17678c5/openshift-4.0/images/cluster-monitoring-operator.yml).
 
cc @s-urbaniak @pgier 