### PR TITLE
Add router-base to the 4.0 build, base haproxy-router off it

### DIFF
--- a/images/openshift-enterprise-haproxy-router.yml
+++ b/images/openshift-enterprise-haproxy-router.yml
@@ -8,7 +8,7 @@ content:
       url: git@github.com:openshift/router.git
     path: images/router/haproxy
 from:
-  member: ose-haproxy-router-base
+  member: openshift-enterprise-router-base
 labels:
   License: GPLv2+
   io.k8s.description: This is a component of OpenShift Container Platform and contains

--- a/images/openshift-enterprise-router-base.yml
+++ b/images/openshift-enterprise-router-base.yml
@@ -1,0 +1,23 @@
+mode: wip
+base_only: true
+content:
+  source:
+    dockerfile: Dockerfile.rhel
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+        fallback: master
+      url: git@github.com:openshift/router.git
+    path: images/router/base
+from:
+  member: openshift-enterprise-base
+labels:
+  License: GPLv2+
+  io.k8s.description: This is the base image from which all template based routers inherit.
+  io.k8s.display-name: OpenShift Container Platform Router
+  io.openshift.tags: openshift,router
+  vendor: Red Hat
+name: openshift/ose-router-base
+owners: []
+enabled_repos:
+- rhel-server-ose-rpms


### PR DESCRIPTION
The haproxy-router was moved to stop using `oc` to contain its router
content, and a new router-base image was created to be the common base
for any future template based router. The binary used by haproxy-router
lives in router-base and was missing from the previous version of
haproxy-router, which fixes an OCP only error:

    no such executable: /usr/bin/openshift-router