### PR TITLE
Fix configmap-reload name. Shouldn't have had that 'er' before

### DIFF
--- a/images/configmap-reload.yml
+++ b/images/configmap-reload.yml
@@ -18,6 +18,6 @@ labels:
   io.k8s.display-name: configmap reload
   io.openshift.tags: kubernetes
   vendor: Red Hat
-name: openshift/ose-configmap-reloader
+name: openshift/ose-configmap-reload
 owners:
 - fbranczy@redhat.com


### PR DESCRIPTION
This busted up the beta1 drop last night. Fixing it permanently now.