### PR TITLE
Add ppc64le repos for 4.0

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -1,5 +1,7 @@
 arches:
 - x86_64
+#- ppc64le
+
 branch: rhaos-{MAJOR}.{MINOR}-rhel-7
 name: openshift-{MAJOR}.{MINOR}
 urls:
@@ -26,76 +28,123 @@ sources:
 repos:
   rhel-7-server-ansible-2.4-rpms:
     conf:
-      baseurl: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/ansible/2.4/os/
+      baseurl:
+        ppc64le: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/power-le/7/7Server/ppc64le/ansible/2.4/os/
+        x86_64: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/ansible/2.4/os/
     content_set:
       default: rhel-7-server-ansible-2.4-rpms
+      ppc64le: rhel-7-server-ansible-2.4-for-power-le-rpms
   rhel-7-server-ansible-2.5-rpms:
     conf:
-      baseurl: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/ansible/2.5/os/
+      baseurl:
+        ppc64le: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/power-le/7/7Server/ppc64le/ansible/2.5/os/
+        x86_64: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/ansible/2.5/os/
     content_set:
       default: rhel-7-server-ansible-2.5-rpms
+      ppc64le: rhel-7-server-ansible-2.5-for-power-le-rpms
   rhel-7-server-ansible-2.6-rpms:
     conf:
-      baseurl: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/ansible/2.6/os/
+      baseurl:
+        ppc64le: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/power-le/7/7Server/ppc64le/ansible/2.6/os/
+        x86_64: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/ansible/2.6/os/
     content_set:
       default: rhel-7-server-ansible-2.6-rpms
+      ppc64le: rhel-7-server-ansible-2.6-for-power-le-rpms
   rhel-7-server-rhceph-3-tools-rpms:
     conf:
-      baseurl: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/rhceph-tools/3/os/
+      baseurl:
+        ppc64le: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/power-le/7/7Server/ppc64le/rhceph-tools/3/os/
+        x86_64: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/rhceph-tools/3/os/
     content_set:
       default: rhel-7-server-rhceph-3-tools-rpms
+      optional: true
+      ppc64le: rhel-7-server-rhceph-3-for-power-le-tools-rpms
   rhel-fast-datapath-htb-rpms:
     conf:
-      baseurl: http://pulp.dist.prod.ext.phx2.redhat.com/content/htb/rhel/server/7/x86_64/fast-datapath/os/
+      baseurl:
+        ppc64le: http://pulp.dist.prod.ext.phx2.redhat.com/content/beta/rhel/power-le/7/ppc64le/fast-datapath/os/
+        x86_64: http://pulp.dist.prod.ext.phx2.redhat.com/content/htb/rhel/server/7/x86_64/fast-datapath/os/
     content_set:
       default: rhel-7-fast-datapath-htb-rpms
+      optional: true
+      ppc64le: rhel-7-for-power-le-fast-datapath-beta-rpms
   rhel-fast-datapath-rpms:
     conf:
       baseurl:
-        signed: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/fast-datapath/os/
-        unsigned: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/fast-datapath/os/
+        unsigned:
+          ppc64le: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/power-le/7/7Server/ppc64le/fast-datapath/os/
+          x86_64: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/fast-datapath/os/
+        signed:
+          ppc64le: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/power-le/7/7Server/ppc64le/fast-datapath/os/
+          x86_64: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/fast-datapath/os/
     content_set:
       default: rhel-7-fast-datapath-rpms
+      ppc64le: rhel-7-for-power-le-fast-datapath-rpms
   rhel-server-extras-rpms:
     conf:
-      baseurl: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/extras/os/
+      baseurl:
+        ppc64le: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/power-le/7/7Server/ppc64le/extras/os/
+        x86_64: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/extras/os/
     content_set:
       default: rhel-7-server-extras-rpms
+      ppc64le: rhel-7-for-power-le-extras-rpms
   rhel-server-optional-rpms:
     conf:
-      baseurl: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/optional/os/
+      baseurl:
+        ppc64le: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/power-le/7/7Server/ppc64le/optional/os/
+        x86_64: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/optional/os/
       enabled: 1
     content_set:
       default: rhel-7-server-optional-rpms
+      ppc64le: rhel-7-for-power-le-optional-rpms
   rhel-server-ose-OLD_NODE_JS-rpms:
     conf:
-      baseurl: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/AtomicOpenShift-signed/3.2/building/RH7-RHAOS-3.2/x86_64/os/
+      baseurl:
+        ppc64le: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/AtomicOpenShift-signed/3.2/building/RH7-RHAOS-3.2/ppc64le/os/
+        x86_64: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/AtomicOpenShift-signed/3.2/building/RH7-RHAOS-3.2/x86_64/os/
     content_set:
       default: rhel-7-server-ose-3.2-rpms
+      optional: true
+      ppc64le: rhel-7-for-power-le-ose-3.2-rpms
   rhel-server-ose-rpms:
     conf:
       baseurl:
-        signed: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/AtomicOpenShift-signed/{MAJOR}.{MINOR}/building/RH7-RHAOS-{MAJOR}.{MINOR}/x86_64/os
-        unsigned: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/AtomicOpenShift/{MAJOR}.{MINOR}/building/x86_64/os
+        unsigned:
+          ppc64le: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/AtomicOpenShift/{MAJOR}.{MINOR}/building/ppc64le/os
+          x86_64: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/AtomicOpenShift/{MAJOR}.{MINOR}/building/x86_64/os
+        signed:
+          ppc64le: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/AtomicOpenShift-signed/{MAJOR}.{MINOR}/building/RH7-RHAOS-{MAJOR}.{MINOR}/ppc64le/os
+          x86_64: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/AtomicOpenShift-signed/{MAJOR}.{MINOR}/building/RH7-RHAOS-{MAJOR}.{MINOR}/x86_64/os
     content_set:
       default: rhel-7-server-ose-{MAJOR}.{MINOR}-rpms
       optional: true
-  rhel-server-rh-common-rpms:
+      ppc64le: rhel-7-for-power-le-ose-{MAJOR}.{MINOR}-rpms
+  rhel-server-ose-rpms-shipped:
     conf:
-      baseurl: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/rh-common/os/
+      baseurl:
+        ppc64le: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/power-le/7/7Server/ppc64le/ose/{MAJOR}.{MINOR}/os/
+        x86_64: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/ose/{MAJOR}.{MINOR}/os/
     content_set:
-      default: rhel-7-server-rh-common-rpms
+      default: rhel-7-server-ose-{MAJOR}.{MINOR}-rpms
+      optional: true
+      ppc64le: rhel-7-for-power-le-ose-{MAJOR}.{MINOR}-rpms
   rhel-server-rhscl-rpms:
     conf:
-      baseurl: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/rhscl/1/os/
+      baseurl:
+        ppc64le: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/power-le/7/7Server/ppc64le/rhscl/1/os/
+        x86_64: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/rhscl/1/os/
     content_set:
       default: rhel-server-rhscl-7-rpms
+      ppc64le: rhel-7-server-for-power-le-rhscl-rpms
   rhel-server-rpms:
     conf:
-      baseurl: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/os/
+      baseurl:
+        ppc64le: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/power-le/7/7Server/ppc64le/os/
+        x86_64: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/os/
       enabled: 1
     content_set:
       default: rhel-7-server-rpms
+      ppc64le: rhel-7-for-power-le-rpms
 vars:
   MAJOR: 4
   MINOR: 0


### PR DESCRIPTION
Adding ppc64le repos for 4.0 ppc64le support. 
A few containers (18ish) don't build, so for now we should leave -ppc64le commented out. 
I'll open a separate PR to uncomment when everything is ready to go.

