### PR TITLE
Include master jenkins image in release payload

### DIFF
--- a/images/openshift-jenkins-2.yml
+++ b/images/openshift-jenkins-2.yml
@@ -17,7 +17,7 @@ labels:
   io.k8s.display-name: Jenkins 2
   io.openshift.tags: jenkins,jenkins2,ci
   vendor: Red Hat
-name: openshift/jenkins-2-rhel7
+name: openshift/ose-jenkins-2-rhel7
 odcs:
   packages:
     exclude:


### PR DESCRIPTION
Add `ose-` prefix to master jenkins image. Allows image to be incorporated in release payload.