### PR TITLE
jenkins master, base agent images now base off of cli image

### DIFF
--- a/images/jenkins-slave-base-rhel7.yml
+++ b/images/jenkins-slave-base-rhel7.yml
@@ -8,7 +8,7 @@ content:
       url: git@github.com:openshift/jenkins.git
     path: slave-base
 from:
-  member: openshift-enterprise
+  member: openshift-enterprise-cli
 labels:
   License: GPLv2+
   io.k8s.description: The jenkins slave base image is intended to be built on top

--- a/images/openshift-jenkins-2.yml
+++ b/images/openshift-jenkins-2.yml
@@ -10,7 +10,7 @@ content:
 enabled_repos:
 - rhel-server-ose-rpms
 from:
-  member: openshift-enterprise
+  member: openshift-enterprise-cli
 labels:
   License: GPLv2+
   io.k8s.description: Jenkins is a continuous integration server


### PR DESCRIPTION
@adammhaile @joeldavis84 ptal

This is my attempt to replicate on the osbs side what @bparees has done in https://github.com/openshift/jenkins/pull/774

We are now basing the openshift/jenkins images off of origin/ose cli (i.e. we only need `oc`, not all the server side binaries)

Of course if this is not the starting point for you process please advise.  We simply thought this would be the most helpful way to initiate this change on your side of things.

thanks