### PR TITLE
Move some images out of ose into their own repo

### DIFF
--- a/images/openshift-enterprise-base.yml
+++ b/images/openshift-enterprise-base.yml
@@ -1,12 +1,13 @@
 base_only: true
 content:
   source:
-    alias: ose
-    modifications:
-    - action: replace
-      match: COPY *.repo /etc/yum.repos.d/
-      replacement: ''
-    path: images/base
+    dockerfile: Dockerfile.rhel
+    git:
+      branch:
+        fallback: master
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift/images.git
+    path: base
 from:
   stream: rhel
 labels:

--- a/images/openshift-enterprise-egress-dns-proxy.yml
+++ b/images/openshift-enterprise-egress-dns-proxy.yml
@@ -1,7 +1,11 @@
 content:
   source:
-    alias: ose
-    path: images/egress/dns-proxy
+    git:
+      branch:
+        fallback: master
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift/images.git
+    path: egress/dns-proxy
 distgit:
   component: openshift-enterprise-egress-dns-proxy-container
   namespace: containers

--- a/images/openshift-enterprise-egress-router.yml
+++ b/images/openshift-enterprise-egress-router.yml
@@ -1,7 +1,11 @@
 content:
   source:
-    alias: ose
-    path: images/egress/router
+    git:
+      branch:
+        fallback: master
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift/images.git
+    path: egress/router
 from:
   member: openshift-enterprise-base
 labels:

--- a/images/openshift-enterprise-keepalived-ipfailover.yml
+++ b/images/openshift-enterprise-keepalived-ipfailover.yml
@@ -1,7 +1,11 @@
 content:
   source:
-    alias: ose
-    path: images/ipfailover/keepalived
+    path: ipfailover/keepalived
+    git:
+      branch:
+        fallback: master
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift/images.git
 from:
   member: openshift-enterprise-base
 labels:

--- a/images/openshift-enterprise-pod.yml
+++ b/images/openshift-enterprise-pod.yml
@@ -1,14 +1,14 @@
 content:
   source:
-    alias: ose
-    modifications:
-    - action: replace
-      match: origin-pod
-      replacement: atomic-openshift-pod
-    path: images/pod
-enabled_repos:
-- rhel-server-ose-rpms
+    dockerfile: pod/Dockerfile.rhel
+    git:
+      branch:
+        fallback: master
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift/images.git
 from:
+  builder:
+  - image: openshift/golang-builder:1.10
   member: openshift-enterprise-base
 labels:
   License: GPLv2+

--- a/images/ose-egress-http-proxy.yml
+++ b/images/ose-egress-http-proxy.yml
@@ -1,7 +1,11 @@
 content:
   source:
-    alias: ose
-    path: images/egress/http-proxy
+    path: egress/http-proxy
+    git:
+      branch:
+        fallback: master
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift/images.git
 from:
   member: openshift-enterprise-base
 labels:


### PR DESCRIPTION
The base image should be rebuilt less often, and the others benefit
from faster build times being out of the main repo.

Before merging:

* [ ] needs dist git created for github.com/openshift/images.git https://projects.engineering.redhat.com/browse/RCM-51676
* [x] CI needs to be up and running
* [x] Clayton needs to validate everyone else correctly builds before we change the base