### PR TITLE
Use the new unified `Dockerfile.rhel` images for origin

### DIFF
--- a/images/openshift-enterprise-cli.yml
+++ b/images/openshift-enterprise-cli.yml
@@ -1,16 +1,14 @@
 content:
   source:
     alias: ose
-    modifications:
-    - action: replace
-      match: origin-clients
-      replacement: atomic-openshift-clients
-    path: images/cli
+    dockerfile: images/cli/Dockerfile.rhel
 distgit:
   namespace: containers
 enabled_repos:
 - rhel-server-ose-rpms
 from:
+  builder:
+  - stream: golang
   member: openshift-enterprise-base
 labels:
   License: GPLv2+

--- a/images/openshift-enterprise-deployer.yml
+++ b/images/openshift-enterprise-deployer.yml
@@ -1,7 +1,7 @@
 content:
   source:
     alias: ose
-    path: images/deployer
+    dockerfile: images/deployer/Dockerfile.rhel
 from:
   member: openshift-enterprise-cli
 labels:

--- a/images/openshift-enterprise-hyperkube.yml
+++ b/images/openshift-enterprise-hyperkube.yml
@@ -1,16 +1,14 @@
 content:
   source:
     alias: ose
-    modifications:
-    - action: replace
-      match: origin-hyperkube
-      replacement: atomic-openshift-hyperkube
-    path: images/hyperkube
+    dockerfile: images/hyperkube/Dockerfile.rhel
 distgit:
   namespace: containers
 enabled_repos:
 - rhel-server-ose-rpms
 from:
+  builder:
+  - stream: golang
   member: openshift-enterprise-base
 labels:
   License: GPLv2+

--- a/images/openshift-enterprise-hypershift.yml
+++ b/images/openshift-enterprise-hypershift.yml
@@ -1,16 +1,14 @@
 content:
   source:
     alias: ose
-    modifications:
-    - action: replace
-      match: origin-hypershift
-      replacement: atomic-openshift-hypershift
-    path: images/hypershift
+    dockerfile: images/hypershift/Dockerfile.rhel
 distgit:
   namespace: containers
 enabled_repos:
 - rhel-server-ose-rpms
 from:
+  builder:
+  - stream: golang
   member: openshift-enterprise-base
 labels:
   License: GPLv2+

--- a/images/openshift-enterprise-node.yml
+++ b/images/openshift-enterprise-node.yml
@@ -1,16 +1,8 @@
 content:
   source:
     alias: ose
+    dockerfile: images/sdn/Dockerfile.rhel
     modifications:
-    - action: replace
-      match: origin-sdn-ovs
-      replacement: atomic-openshift-sdn-ovs
-    - action: replace
-      match: origin-hyperkube
-      replacement: atomic-openshift-hyperkube
-    - action: replace
-      match: origin-node
-      replacement: atomic-openshift-node
     - action: replace
       match: rpm -V $INSTALL_PKGS &&
       replacement: null
@@ -21,7 +13,9 @@ enabled_repos:
 - rhel-fast-datapath-candidate-rpms
 - rhel-server-extras-rpms
 from:
-  member: openshift-enterprise
+  builder:
+  - stream: golang
+  member: openshift-enterprise-base
 labels:
   License: GPLv2+
   io.k8s.description: This is a component of OpenShift Container Platform and contains
@@ -29,5 +23,6 @@ labels:
   io.k8s.display-name: OpenShift Container Platform Node
   io.openshift.tags: openshift,node
   vendor: Red Hat
+# TODO: this will become openshift/ose-sdn in 4.1
 name: openshift/ose-node
 required: true

--- a/images/openshift-enterprise-recycler.yml
+++ b/images/openshift-enterprise-recycler.yml
@@ -1,7 +1,7 @@
 content:
   source:
     alias: ose
-    path: images/recycler
+    dockerfile: images/recycler/Dockerfile.rhel
 from:
   member: openshift-enterprise-cli
 labels:

--- a/images/openshift-enterprise-tests.yml
+++ b/images/openshift-enterprise-tests.yml
@@ -1,16 +1,14 @@
 content:
   source:
     alias: ose
-    modifications:
-    - action: replace
-      match: origin-tests
-      replacement: atomic-openshift-tests
-    path: images/tests
+    dockerfile: images/tests/Dockerfile.rhel
 distgit:
   namespace: containers
 enabled_repos:
 - rhel-server-ose-rpms
 from:
+  builder:
+  - stream: golang
   member: openshift-enterprise-cli
 labels:
   License: GPLv2+

--- a/images/openshift-enterprise.yml
+++ b/images/openshift-enterprise.yml
@@ -24,6 +24,7 @@ labels:
   io.k8s.display-name: OpenShift Container Platform Application Platform
   io.openshift.tags: openshift,core
   vendor: Red Hat
+mode: disabled
 name: openshift/ose-control-plane
 owners: []
 push:

--- a/images/template-service-broker.yml
+++ b/images/template-service-broker.yml
@@ -1,15 +1,12 @@
 content:
   source:
     alias: ose
-    dockerfile: Dockerfile
-    modifications:
-    - action: replace
-      match: INSTALL_PKGS="origin
-      replacement: INSTALL_PKGS="atomic-openshift
-    path: images/template-service-broker
+    dockerfile: images/template-service-broker/Dockerfile.rhel
 enabled_repos:
 - rhel-server-ose-rpms
 from:
+  builder:
+  - stream: golang
   member: openshift-enterprise-base
 labels:
   License: GPLv2+


### PR DESCRIPTION
These are the new locations for these files that removes dependencies
on RPMs and moves to multi-stage builds. After this merges we can start dropping RPMs from being built
in origin and OCP for everything except `kubelet` and `oc`.