### PR TITLE
add replacement for jenkins-2 image to facilitate Dockerfile changes …

### DIFF
--- a/images/openshift-jenkins-2.yml
+++ b/images/openshift-jenkins-2.yml
@@ -7,6 +7,10 @@ content:
         target: openshift-{MAJOR}.{MINOR}
       url: git@github.com:openshift/jenkins.git
     path: '2'
+    modifications:
+    - action: replace
+      match: INSTALL_JENKINS_VIA_RPMS=false
+      replacement: INSTALL_JENKINS_VIA_RPMS=true
 enabled_repos:
 - rhel-server-ose-rpms
 from:


### PR DESCRIPTION
…when running on  api.ci vs osbs/brew

@adammhaile @sosiouxme ptal

per our conversation in the ART slack channel today

@bparees @adambkaplan fyi ... once this drops, I have an openshift/jenkins change ready to push that will leverage this so that we can download plugins when building on api.ci, but install RPMs when running in osbs/brew