### PR TITLE
cri-o: "temporary" replace needed

### DIFF
--- a/images/cri-o.yml
+++ b/images/cri-o.yml
@@ -1,4 +1,8 @@
 content:
+  modifications:
+  - action: replace
+    match: skopeo-containers
+    replacement: containers-common
   source:
     git:
       branch:


### PR DESCRIPTION
Unless/until we can get https://github.com/kubernetes-sigs/cri-o/pull/1966/files
to merge, we'll need this modification to keep the build from failing.