### PR TITLE
true up image names with OKD

### DIFF
--- a/images/baremetal-machine-controller.yml
+++ b/images/baremetal-machine-controller.yml
@@ -9,7 +9,7 @@ from:
   builder:
   - stream: golang
   member: openshift-enterprise-base
-name: openshift/baremetal-machine-controllers
+name: openshift/ose-baremetal-machine-controller
 owners:
 - kni-devel@redhat.com
 - kni-deployment-devel@redhat.com

--- a/images/csi-provisioner.yml
+++ b/images/csi-provisioner.yml
@@ -18,6 +18,6 @@ labels:
   io.k8s.display-name: External provisioner for CSI volumes
   io.openshift.tags: csi,storage,provisioner
   vendor: Red Hat
-name: openshift/ose-csi-provisioner
+name: openshift/ose-csi-external-provisioner
 owners:
 - jsafrane@redhat.com


### PR DESCRIPTION
These are the names we would have if we matched upstream CI config.

There are other upstream names OCP just doesn't have at all yet AFAICS.