### PR TITLE
update etcd3-docker.yml to change mode: disabled

### DIFF
--- a/images/etcd3-docker.yml
+++ b/images/etcd3-docker.yml
@@ -1,3 +1,4 @@
+mode: disabled
 distgit:
   namespace: rpms
   branch: extras-rhel-7.3


### PR DESCRIPTION
since buildvm-maint failed due to `oc mirror failed: missing or empty Content-Type headererror: an error occurred during planning`