### PR TITLE
adding missing owner images for 4.1

### DIFF
--- a/images/golang-github-prometheus-alertmanager.yml
+++ b/images/golang-github-prometheus-alertmanager.yml
@@ -20,3 +20,5 @@ labels:
   vendor: Red Hat
 name: openshift/ose-prometheus-alertmanager
 required: true
+owners:
+- team-monitoring@redhat.com

--- a/images/golang-github-prometheus-node_exporter.yml
+++ b/images/golang-github-prometheus-node_exporter.yml
@@ -20,5 +20,6 @@ labels:
   io.openshift.tags: openshift,node
   vendor: Red Hat
 name: openshift/ose-prometheus-node-exporter
-owners: []
+owners:
+- team-monitoring@redhat.com
 required: true

--- a/images/golang-github-prometheus-prometheus.yml
+++ b/images/golang-github-prometheus-prometheus.yml
@@ -20,3 +20,5 @@ labels:
   vendor: Red Hat
 name: openshift/ose-prometheus
 required: true
+owners:
+- team-monitoring@redhat.com

--- a/images/image-inspector.yml
+++ b/images/image-inspector.yml
@@ -8,4 +8,6 @@ labels:
   vendor: Red Hat
 mode: disabled
 name: openshift/image-inspector
-owners: []
+owners:
+- cben@redhat.com
+- nshneor@redhat.com

--- a/images/logging-eventrouter.yml
+++ b/images/logging-eventrouter.yml
@@ -15,3 +15,5 @@ push:
   repos:
   - openshift/logging-eventrouter
   - openshift/ose-logging-eventrouter
+owners:
+- aos-logging@redhat.com

--- a/images/openshift-enterprise-autoheal.yml
+++ b/images/openshift-enterprise-autoheal.yml
@@ -21,4 +21,5 @@ labels:
   io.openshift.tags: openshift
   vendor: Red Hat
 name: openshift/ose-autoheal
-owners: []
+owners:
+- jhernand@redhat.com

--- a/images/openshift-enterprise-base.yml
+++ b/images/openshift-enterprise-base.yml
@@ -19,3 +19,5 @@ labels:
   vendor: Red Hat
 name: openshift/ose-base
 required: true
+owners:
+- ccoleman@redhat.com

--- a/images/openshift-enterprise-cli.yml
+++ b/images/openshift-enterprise-cli.yml
@@ -19,3 +19,5 @@ labels:
   vendor: Red Hat
 name: openshift/ose-cli
 required: true
+owners:
+- aos-master@redhat.com

--- a/images/openshift-enterprise-deployer.yml
+++ b/images/openshift-enterprise-deployer.yml
@@ -13,5 +13,6 @@ labels:
   io.openshift.tags: openshift,deployer
   vendor: Red Hat
 name: openshift/ose-deployer
-owners: []
+owners:
+- aos-master@redhat.com
 required: true

--- a/images/openshift-enterprise-egress-dns-proxy.yml
+++ b/images/openshift-enterprise-egress-dns-proxy.yml
@@ -20,4 +20,5 @@ labels:
   io.openshift.tags: openshift,egress,dns,proxy
   vendor: Red Hat
 name: openshift/ose-egress-dns-proxy
-owners: []
+owners:
+- aos-network-edge@redhat.com

--- a/images/openshift-enterprise-egress-router.yml
+++ b/images/openshift-enterprise-egress-router.yml
@@ -16,4 +16,5 @@ labels:
   io.openshift.tags: openshift,router,egress
   vendor: Red Hat
 name: openshift/ose-egress-router
-owners: []
+owners:
+- aos-network-edge@redhat.com

--- a/images/openshift-enterprise-haproxy-router.yml
+++ b/images/openshift-enterprise-haproxy-router.yml
@@ -20,5 +20,6 @@ labels:
   io.openshift.tags: openshift,router,haproxy
   vendor: Red Hat
 name: openshift/ose-haproxy-router
-owners: []
+owners:
+- aos-network-edge@redhat.com
 required: true

--- a/images/openshift-enterprise-hyperkube.yml
+++ b/images/openshift-enterprise-hyperkube.yml
@@ -18,4 +18,6 @@ labels:
   io.openshift.tags: openshift,hyperkube
   vendor: Red Hat
 name: openshift/ose-hyperkube
+owners:
+  - aos-master@redhat.com
 required: true

--- a/images/openshift-enterprise-hypershift.yml
+++ b/images/openshift-enterprise-hypershift.yml
@@ -18,4 +18,6 @@ labels:
   io.openshift.tags: openshift,hypershift
   vendor: Red Hat
 name: openshift/ose-hypershift
+owners:
+  - aos-master@redhat.com
 required: true

--- a/images/openshift-enterprise-keepalived-ipfailover.yml
+++ b/images/openshift-enterprise-keepalived-ipfailover.yml
@@ -17,4 +17,5 @@ labels:
   io.openshift.tags: openshift,ha,ip,failover
   vendor: Red Hat
 name: openshift/ose-keepalived-ipfailover
-owners: []
+owners:
+- aos-network-edge@redhat.com

--- a/images/openshift-enterprise-mariadb.yml
+++ b/images/openshift-enterprise-mariadb.yml
@@ -9,4 +9,5 @@ labels:
   vendor: Red Hat
 name: openshift/mariadb-apb
 no_oit_comments: true
-owners: []
+owners:
+- ao-team@redhat.com

--- a/images/openshift-enterprise-mediawiki.apb.yml
+++ b/images/openshift-enterprise-mediawiki.apb.yml
@@ -9,5 +9,6 @@ labels:
   vendor: Red Hat
 name: openshift/mediawiki-apb
 no_oit_comments: true
-owners: []
+owners:
+- ao-team@redhat.com
 wait_for: openshift-enterprise-mediawiki.container

--- a/images/openshift-enterprise-mediawiki.container.yml
+++ b/images/openshift-enterprise-mediawiki.container.yml
@@ -7,4 +7,5 @@ labels:
   License: GPLv2+
   vendor: Red Hat
 name: openshift/mediawiki
-owners: []
+owners:
+- ao-team@redhat.com

--- a/images/openshift-enterprise-mysql.yml
+++ b/images/openshift-enterprise-mysql.yml
@@ -9,4 +9,5 @@ labels:
   vendor: Red Hat
 name: openshift/mysql-apb
 no_oit_comments: true
-owners: []
+owners:
+- ao-team@redhat.com

--- a/images/openshift-enterprise-node.yml
+++ b/images/openshift-enterprise-node.yml
@@ -21,3 +21,5 @@ labels:
 # TODO: this will become openshift/ose-sdn in 4.1
 name: openshift/ose-node
 required: true
+owners:
+  - aos-pod@redhat.com

--- a/images/openshift-enterprise-pod.yml
+++ b/images/openshift-enterprise-pod.yml
@@ -18,4 +18,5 @@ labels:
   io.openshift.tags: openshift,pod
   vendor: Red Hat
 name: openshift/ose-pod
-owners: []
+owners:
+- aos-pod@redhat.com

--- a/images/openshift-enterprise-postgresql.yml
+++ b/images/openshift-enterprise-postgresql.yml
@@ -9,4 +9,5 @@ labels:
   vendor: Red Hat
 name: openshift/postgresql-apb
 no_oit_comments: true
-owners: []
+owners:
+- ao-team@redhat.com

--- a/images/openshift-enterprise-recycler.yml
+++ b/images/openshift-enterprise-recycler.yml
@@ -12,4 +12,5 @@ labels:
   io.openshift.tags: openshift,recycler
   vendor: Red Hat
 name: openshift/ose-recycler
-owners: []
+owners:
+- aos-storage-devel@redhat.com

--- a/images/openshift-enterprise-tests.yml
+++ b/images/openshift-enterprise-tests.yml
@@ -18,3 +18,5 @@ labels:
   io.openshift.tags: openshift,tests,e2e
   vendor: Red Hat
 name: openshift/ose-tests
+owners:
+- aos-master@redhat.com

--- a/images/openshift-local-storage.yml
+++ b/images/openshift-local-storage.yml
@@ -9,4 +9,5 @@ labels:
   io.openshift.tags: local,dynamic,provisioner
   vendor: Red Hat
 name: openshift/local-storage-provisioner
-owners: []
+owners:
+- aos-storage-devel@redhat.com

--- a/images/ose-egress-http-proxy.yml
+++ b/images/ose-egress-http-proxy.yml
@@ -16,4 +16,5 @@ labels:
   io.openshift.tags: openshift,http-proxy,egress
   vendor: Red Hat
 name: openshift/ose-egress-http-proxy
-owners: []
+owners:
+- aos-network-edge@redhat.com

--- a/images/ose-haproxy-router-base.yml
+++ b/images/ose-haproxy-router-base.yml
@@ -21,4 +21,5 @@ labels:
   io.openshift.tags: openshift,router
   vendor: Red Hat
 name: openshift/ose-haproxy-router-base
-owners: []
+owners:
+- aos-network-edge@redhat.com

--- a/images/snapshot-controller.yml
+++ b/images/snapshot-controller.yml
@@ -9,4 +9,5 @@ labels:
   io.openshift.tags: dynamic,controller
   vendor: Red Hat
 name: openshift/ose-snapshot-controller
-owners: []
+owners:
+- aos-storage-devel@redhat.com

--- a/images/snapshot-provisioner.yml
+++ b/images/snapshot-provisioner.yml
@@ -9,4 +9,5 @@ labels:
   io.openshift.tags: dynamic,provisioner
   vendor: Red Hat
 name: openshift/ose-snapshot-provisioner
-owners: []
+owners:
+- aos-storage-devel@redhat.com


### PR DESCRIPTION
Here's all the missing owner files in 4.1, I'm tracking down one by one with group lead, still wip

- [x] golang-github-prometheus-alertmanager
- [x] golang-github-prometheus-node_exporter
- [x] golang-github-prometheus-prometheus
- [x] image-inspector  ~(for this one, still waiting for Federico Simoncelli to confirm)~
- [x] logging-eventrouter
- [x] openshift-enterprise
- [x] openshift-enterprise-asb  (no release)
- [x] ~openshift-enterprise-autoheal~   (Juan Hernandez told me is a dead project)
- [x] openshift-enterprise-base
- [x] openshift-enterprise-cli
- [x] openshift-enterprise-deployer
- [x] openshift-enterprise-egress-dns-proxy
- [x] openshift-enterprise-egress-router
- [x] openshift-enterprise-haproxy-router
- [x] openshift-enterprise-hyperkube
- [x] openshift-enterprise-hypershift
- [x] openshift-enterprise-keepalived-ipfailover
- [x] openshift-enterprise-mariadb
- [x] openshift-enterprise-mediawiki.apb
- [x] openshift-enterprise-mediawiki.container
- [x] openshift-enterprise-mysql
- [x] openshift-enterprise-node
- [x] openshift-enterprise-pod
- [x] openshift-enterprise-postgresql
- [x] openshift-enterprise-recycler
- [x] openshift-enterprise-tests
- [x] openshift-local-storage
- [x] ose-cli-artifacts
- [x] ose-egress-http-proxy
- [x] ose-haproxy-router-base
- [x] snapshot-controller
- [x] snapshot-provisioner