### PR TITLE
mark cli-artifacts as x86_64 only

### DIFF
--- a/images/ose-cli-artifacts.yml
+++ b/images/ose-cli-artifacts.yml
@@ -14,3 +14,5 @@ name: openshift/ose-cli-artifacts
 owners:
 - ccoleman@redhat.com
 required: true
+arches:
+- x86_64


### PR DESCRIPTION
No need to build  the cli-artifacts container on other architectures.