### PR TITLE
Switch to go 1.11

### DIFF
--- a/images/ose-cluster-kube-scheduler-operator.yml
+++ b/images/ose-cluster-kube-scheduler-operator.yml
@@ -8,7 +8,7 @@ content:
       url: git@github.com:openshift/cluster-kube-scheduler-operator.git
 from:
   builder:
-  - stream: golang
+  - stream: golang-1.11
   member: openshift-enterprise-base
 name: openshift/ose-cluster-kube-scheduler-operator
 owners:


### PR DESCRIPTION
Start using golang 1.11

/cc @soltysh @sjenning 

https://github.com/openshift/cluster-kube-scheduler-operator/pull/102