### PR TITLE
Add golang module paths for Network Edge components

### DIFF
--- a/images/ose-cluster-dns-operator.yml
+++ b/images/ose-cluster-dns-operator.yml
@@ -5,6 +5,10 @@ content:
         fallback: master
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift/cluster-dns-operator.git
+container_yaml:
+  go:
+    modules:
+    - module: github.com/openshift/cluster-dns-operator
 from:
   builder:
   - stream: golang

--- a/images/ose-cluster-ingress-operator.yml
+++ b/images/ose-cluster-ingress-operator.yml
@@ -5,6 +5,10 @@ content:
         fallback: master
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift/cluster-ingress-operator.git
+container_yaml:
+  go:
+    modules:
+    - module: github.com/openshift/cluster-ingress-operator
 from:
   builder:
   - stream: golang

--- a/images/ose-haproxy-router-base.yml
+++ b/images/ose-haproxy-router-base.yml
@@ -7,6 +7,10 @@ content:
         fallback: master
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift/router.git
+container_yaml:
+  go:
+    modules:
+    - module: github.com/openshift/router
 enabled_repos:
 - rhel-server-ose-rpms
 from:


### PR DESCRIPTION
Add container_yaml stanzas for the Network Edge team's images.

Note that building the base-router image involves building the Go-based openshift-router binary, but building the haproxy-router image only layers RPMs and some configuration on top of the base-router image without itself building any Go code.  Thus this PR only adds a stanza to the base-router config, not to the haproxy-router config.

Building the egress-http-proxy image also does not involve building any Go code.

* `images/ose-cluster-dns-operator.yml`:
* `images/ose-cluster-ingress-operator.yml`:
* `images/ose-haproxy-router-base.yml`: Add `container_yaml` stanza.

---

@openshift/sig-network-edge

~I'm not sure what to do about the egress router images; https://github.com/openshift/origin/commit/7aedc3cb19c39e22b382eff96380bef245f92352 removed them from openshift/origin, and I don't know whether they got rehomed.~ Edit: Looks like they got rehomed to openshift/images: https://github.com/openshift/images/tree/release-4.1/egress.  In any case, they do not require building Go code.