### PR TITLE
[4.1] Update DevEx owners

### DIFF
--- a/images/ose-cluster-openshift-controller-manager-operator.yml
+++ b/images/ose-cluster-openshift-controller-manager-operator.yml
@@ -11,5 +11,5 @@ from:
   member: openshift-enterprise-base
 name: openshift/ose-cluster-openshift-controller-manager-operator
 owners:
-- aos-master@redhat.com
+- aos-developer-experience@redhat.com
 required: true

--- a/images/ose-cluster-samples-operator.yml
+++ b/images/ose-cluster-samples-operator.yml
@@ -13,5 +13,5 @@ from:
   stream: rhel
 name: openshift/ose-cluster-samples-operator
 owners:
-- gmontero@redhat.com
+- aos-developer-experience@redhat.com
 required: true


### PR DESCRIPTION
* ose-cluster-samples operator email change
* ose-cluster-openshift-controller-manager-operator now owned by DevEx