### PR TITLE
Bug 1703240: Update base image for ocp build of must-gather.

### DIFF
--- a/images/ose-must-gather.yml
+++ b/images/ose-must-gather.yml
@@ -9,7 +9,7 @@ content:
 from:
   builder:
   - stream: golang
-  member: openshift-enterprise-base
+  member: openshift-enterprise-cli
 name: openshift/ose-must-gather
 owners:
 - aos-master@redhat.com


### PR DESCRIPTION
Changed base image from openshift-enterprise-base to [openshift-enterprise-cli](https://github.com/openshift/ocp-build-data/blob/openshift-4.1/images/openshift-enterprise-cli.yml).