### PR TITLE
enable repos so slave-base can install dumb-init

### DIFF
--- a/images/jenkins-slave-base-rhel7.yml
+++ b/images/jenkins-slave-base-rhel7.yml
@@ -9,6 +9,9 @@ content:
     path: slave-base
 from:
   member: openshift-enterprise
+enabled_repos:
+- rhel-server-ose-rpms
+- rhel-server-ose-rpms-shipped  
 labels:
   License: GPLv2+
   io.k8s.description: The jenkins slave base image is intended to be built on top


### PR DESCRIPTION
@adammhaile @sosiouxme PTAL

@waveywaves @sthaha fyi, here is an example of a change for the jenkins images to facilitate the building of the OSBS/Brew images that RH subscription customers get access to

ref https://github.com/openshift/jenkins/blob/master/CONTRIBUTING_TO_OPENSHIFT_JENKINS_IMAGE_AND_PLUGINS.md#step-2-updating-osbsbrew-for-generating-the-officially-supported-images-available-with-red-hat-subscriptions