### PR TITLE
enable repos so slave-base can install dumb-init

### DIFF
--- a/images/jenkins-slave-base-rhel7.yml
+++ b/images/jenkins-slave-base-rhel7.yml
@@ -9,6 +9,8 @@ content:
     path: slave-base
 from:
   member: openshift-enterprise
+enabled_repos:
+- rhel-server-ose-rpms
 labels:
   License: GPLv2+
   io.k8s.description: The jenkins slave base image is intended to be built on top


### PR DESCRIPTION
@adammhaile @sosiouxme PTAL

only added the 1 repo in the 3.9 version based on https://github.com/openshift/ocp-build-data/blob/openshift-3.9/images/openshift-jenkins-2.yml

@waveywaves @sthaha fyi