### PR TITLE
Remove Kuryr images from non_release list

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -32,8 +32,6 @@ non_release:
   - cluster-nfd-operator
   - csi-provisioner
   - efs-provisioner
-  - kuryr-cni
-  - kuryr-controller
   - ose-haproxy-router-base
   - ose-leader-elector
   - ose-manila-provisioner


### PR DESCRIPTION
With openshift/release#3641 being merged openshift/kuryr-kubernetes has
the CI configuration, which was the reason behind putting it on this
list. This commit removes it from it.