### PR TITLE
Add cluster-update-keys to OCP

### DIFF
--- a/images/ose-cluster-update-keys.yml
+++ b/images/ose-cluster-update-keys.yml
@@ -1,0 +1,14 @@
+content:
+  source:
+    dockerfile: Dockerfile.rhel
+    git:
+      branch:
+        fallback: master
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift/cluster-update-keys.git
+from:
+  member: openshift-enterprise-base
+name: openshift/ose-cluster-update-keys
+owners:
+- aos-art-team@redhat.com
+required: true


### PR DESCRIPTION
This image controls the content that verifies an OCP update payload
is signed.

Still verifying everything, do not merge yet.