### PR TITLE
Remove leader-elector from non_release list

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -30,7 +30,6 @@ non_release:
   - csi-provisioner
   - efs-provisioner
   - ose-haproxy-router-base
-  - ose-leader-elector
   - ose-manila-provisioner
   - snapshot-controller
   - snapshot-provisioner


### PR DESCRIPTION
With openshift/release#3853 merged, openshift/leader-elector is now
built by prow. This should be enough to remove it from non_release list.