### PR TITLE
Update apb-base and ansible-operator to use ansible 2.7 RPM repositories

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -79,6 +79,14 @@ repos:
     content_set:
       default: rhel-7-server-ansible-2.6-rpms
       ppc64le: rhel-7-server-ansible-2.6-for-power-le-rpms
+  rhel-7-server-ansible-2.7-rpms:
+    conf:
+      baseurl:
+        ppc64le: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/power-le/7/7Server/ppc64le/ansible/2.7/os/
+        x86_64: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/ansible/2.7/os/
+    content_set:
+      default: rhel-7-server-ansible-2.7-rpms
+      ppc64le: rhel-7-server-ansible-2.7-for-power-le-rpms
   rhel-7-server-ansible-runner-1.1-rpms:
     conf:
       baseurl:

--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -13,7 +13,7 @@ enabled_repos:
 - rhel-server-ose-rpms
 - rhel-server-extras-rpms
 - rhel-server-optional-rpms
-- rhel-7-server-ansible-2.6-rpms
+- rhel-7-server-ansible-2.7-rpms
 - rhel-7-server-ansible-runner-1.2-rpms
 from:
   builder:

--- a/images/openshift-enterprise-apb-base.yml
+++ b/images/openshift-enterprise-apb-base.yml
@@ -2,7 +2,7 @@ enabled_repos:
 - rhel-server-ose-rpms
 - rhel-server-extras-rpms
 - rhel-server-optional-rpms
-- rhel-7-server-ansible-2.6-rpms
+- rhel-7-server-ansible-2.7-rpms
 - rhel-7-server-ansible-runner-1.1-rpms
 - rhel-7-server-ansible-runner-1.2-rpms
 from:


### PR DESCRIPTION
The upstream repos are using 2.7 from the ansible-runner base, so we should update the OSE images to ansible 2.7 also.

/hold
Needs review from the teams owning ansible-operator and apb images.