### PR TITLE
Remove metering components from non-release list for 4.2

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -34,11 +34,6 @@ non_release:
   - snapshot-controller
   - snapshot-provisioner
   - openshift-enterprise-service-idler
-  - ose-metering-reporting-operator
-  - ose-metering-helm
-  - ose-metering-hive
-  - ose-metering-hadoop
-  - ose-metering-presto
   rpms:
   - atomic-openshift-service-idler
   - atomic-openshift-metrics-server-container


### PR DESCRIPTION
Metering is shipping as a redhat-operator in 4.2 so we need these to be in the marketplace publishing pipeline.