### PR TITLE
Update metering components configs for marketplace publishing in 4.2

### DIFF
--- a/images/hadoop.yml
+++ b/images/hadoop.yml
@@ -16,3 +16,5 @@ name: openshift/ose-metering-hadoop
 owners:
 - czibolsk@redhat.com
 - sd-operator-metering@redhat.com
+dependents:
+- ose-metering-ansible-operator

--- a/images/hive.yml
+++ b/images/hive.yml
@@ -14,3 +14,5 @@ name: openshift/ose-metering-hive
 owners:
 - czibolsk@redhat.com
 - sd-operator-metering@redhat.com
+dependents:
+- ose-metering-ansible-operator

--- a/images/ose-metering-ansible-operator.yml
+++ b/images/ose-metering-ansible-operator.yml
@@ -24,3 +24,6 @@ name: openshift/ose-metering-ansible-operator
 owners:
 - czibolsk@redhat.com
 - sd-operator-metering@redhat.com
+update-csv:
+  manifests-dir: manifests/deploy/openshift/olm/bundle
+  registry: image-registry.openshift-image-registry.svc:5000

--- a/images/ose-metering-helm.yml
+++ b/images/ose-metering-helm.yml
@@ -18,3 +18,5 @@ name: openshift/ose-metering-helm
 owners:
 - czibolsk@redhat.com
 - sd-operator-metering@redhat.com
+dependents:
+- ose-metering-ansible-operator

--- a/images/ose-metering-reporting-operator.yml
+++ b/images/ose-metering-reporting-operator.yml
@@ -18,3 +18,5 @@ name: openshift/ose-metering-reporting-operator
 owners:
 - czibolsk@redhat.com
 - sd-operator-metering@redhat.com
+dependents:
+- ose-metering-ansible-operator

--- a/images/presto.yml
+++ b/images/presto.yml
@@ -14,3 +14,5 @@ name: openshift/ose-metering-presto
 owners:
 - sd-operator-metering@redhat.com
 - czibolsk@redhat.com
+dependents:
+- ose-metering-ansible-operator


### PR DESCRIPTION
OLM manifests are in https://github.com/operator-framework/operator-metering/tree/master/manifests/deploy/openshift/olm/bundle so I think this is correct.