### PR TITLE
[ART-672] Add sriov-network-operator.yml

### DIFF
--- a/images/sriov-network-operator.yml
+++ b/images/sriov-network-operator.yml
@@ -1,0 +1,20 @@
+config: wip
+container_yaml:
+  go:
+    modules:
+    - module: github.com/openshift/sriov-network-operator
+content:
+  source:
+    dockerfile: Dockerfile
+    git:
+      branch:
+        fallback: master
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift/sriov-network-operator.git
+from:
+  builder:
+  - stream: golang
+  member: openshift-enterprise-base
+name: openshift/ose-sriov-network-operator
+owners:
+- multus-dev@redhat.com


### PR DESCRIPTION
As requested in [ART-672](https://jira.coreos.com/browse/ART-672) I'm adding [sriov-network-operator](https://github.com/openshift/sriov-network-operator) to **openshift-4.2**.
(with `config: wip` until a successful execution of our Jenkins "custom" job)