### PR TITLE
Add cluster-update-keys for 4.2 (was not part of branch)

### DIFF
--- a/images/ose-cluster-update-keys.yml
+++ b/images/ose-cluster-update-keys.yml
@@ -1,0 +1,13 @@
+content:
+  source:
+    dockerfile: Dockerfile.rhel
+    git:
+      branch:
+        fallback: master
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift/cluster-update-keys.git
+from:
+  member: openshift-enterprise-base
+name: openshift/ose-cluster-update-keys
+owners:
+- aos-art-team@redhat.com


### PR DESCRIPTION
We added the image to 4.1, but it was not part of the branch to
4.2.