### PR TITLE
[ART-672] Declare manifests on sriov-network-operator

### DIFF
--- a/images/sriov-network-operator.yml
+++ b/images/sriov-network-operator.yml
@@ -8,7 +8,7 @@ content:
     dockerfile: Dockerfile
     git:
       branch:
-        fallback: master
+        fallback: art
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift/sriov-network-operator.git
 from:
@@ -18,3 +18,6 @@ from:
 name: openshift/ose-sriov-network-operator
 owners:
 - multus-dev@redhat.com
+update-csv:
+  manifests-dir: operator-manifests/
+  registry: image-registry.openshift-image-registry.svc:5000


### PR DESCRIPTION
Attempt to address failed build:

```
{"x86_64": {"export_operator_manifests": "RuntimeError(
    'Could not extract operator manifest files.
    Is there a /manifests path in the image?
    404 Client Error: Not Found ({"message":
    "lstat /var/lib/docker/overlay2/.../merged/manifests: no such file or directory"
```

https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=22224111