### PR TITLE
Correct the default advisory key names for 4.2

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -3,7 +3,7 @@ arches:
 #- ppc64le
 
 advisories:
-  images: 43533
+  image: 43533
   rpm: 43535
   # security:
 


### PR DESCRIPTION
Fixes

```
2019-06-24 12:50:43,038 INFO Cloning config data from https://gitlab.cee.redhat.com/openshift-art/ocp-build-data.git
2019-06-24 12:50:46,260 INFO Using branch from group.yml: rhaos-4.2-rhel-7
No value defined for default advisory: The key advisories.image is not defined for group openshift-4.2 in group.yml
```