### PR TITLE
rpms/machine-config-daemon: Target 4.3 dist-git

### DIFF
--- a/rpms/machine-config-daemon.yml
+++ b/rpms/machine-config-daemon.yml
@@ -10,5 +10,3 @@ content:
 name: machine-config-daemon
 owners:
   - coreos-devel@redhat.com
-distgit:
-  branch: rhaos-4.2-rhel-8


### PR DESCRIPTION
I have no idea what I'm doing in this repository, but this
is an attempt to fix this issue:
https://github.com/openshift/os/issues/386

We need git master of [the MCO](https://github.com/openshift/machine-config-operator/)
to show up in the 4.3 composes.

This makes this file look like the other ones.