### PR TITLE
sriov-network-config-daemon: use extras repo not optional

### DIFF
--- a/images/sriov-network-config-daemon.yml
+++ b/images/sriov-network-config-daemon.yml
@@ -12,7 +12,7 @@ content:
       url: git@github.com:openshift/sriov-network-operator.git
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-optional-rpms
+- rhel-server-extras-rpms
 from:
   builder:
   - stream: golang


### PR DESCRIPTION
failing due to missing mstflint pkg which appears to be in extras.
nothing is installing from optional so just removing that.