### PR TITLE
4.3: Provide per advisory kind boilerplate text

### DIFF
--- a/erratatool.yml
+++ b/erratatool.yml
@@ -41,4 +41,82 @@ solution: |
 
 topic: "Red Hat OpenShift Container Platform release 4.3.z is now available with updates to packages and images that fix several bugs and add enhancements."
 
-quality_responsibility_name: 'OpenShift QE'
+quality_responsibility_name: "OpenShift QE"
+
+boilerplates:
+  rpm:
+    synopsis: "OpenShift Container Platform 4.3.z packages update"
+    topic: &common_topic "Red Hat OpenShift Container Platform release 4.3.z is now available with updates to packages and images that fix several bugs."
+    description: &common_description |
+      Red Hat OpenShift Container Platform is Red Hat's cloud computing Kubernetes application platform solution designed for on-premise or private cloud deployments.
+
+      This advisory contains the RPM packages for Red Hat OpenShift Container Platform 4.3.z. See the following advisory for the container images for this release:
+
+      <ADVISORY_URL> e.g. https://access.redhat.com/errata/RHBA-2019:1234
+
+      All OpenShift Container Platform 4.3 users are advised to upgrade to these updated packages and images.
+    solution: &common_solution |
+      Before applying this update, ensure all previously released errata relevant to your system have been applied.
+
+      For OpenShift Container Platform 4.3 see the following documentation, which will be updated shortly for release 4.3.z, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
+
+      https://docs.openshift.com/container-platform/4.3/release_notes/ocp-4-3-release-notes.html
+
+      Details on how to access this content are available at https://docs.openshift.com/container-platform/4.3/updating/updating-cluster-cli.html.
+  image:
+    synopsis: "OpenShift Container Platform 4.3.z bug fix update"
+    topic: *common_topic
+    description: |
+      Red Hat OpenShift Container Platform is Red Hat's cloud computing Kubernetes application platform solution designed for on-premise or private cloud deployments.
+
+      This advisory contains the container images for Red Hat OpenShift Container Platform 4.3.z. See the following advisory for the RPM packages for this release:
+
+      <ADVISORY_URL> e.g. https://access.redhat.com/errata/RHBA-2019:1234
+
+      Space precludes documenting all of the container images in this advisory. See the following Release Notes documentation, which will be updated shortly for this release, for details about these changes:
+
+      https://docs.openshift.com/container-platform/4.3/release_notes/ocp-4-3-release-notes.html
+
+      You may download the oc tool and use it to inspect release image metadata as follows:
+
+        $ oc adm release info quay.io/openshift-release-dev/ocp-release:<RELEASE HERE e.g. 4.3.z>
+
+      The image digest is sha256:<SHASUM_HERE>
+
+      All OpenShift Container Platform 4.3 users are advised to upgrade to these updated packages and images.
+    solution: *common_solution
+  extras:
+    synopsis: OpenShift Container Platform 4.3.z extras update
+    topic: *common_topic
+    description: *common_description
+    solution: *common_solution
+  metadata:
+    synopsis: OpenShift Container Platform 4.3.z OLM Operators metadata update
+    topic: |
+      Red Hat OpenShift Container Platform release 4.3.z is now available with updates to packages and images that fix several bugs.
+
+      This advisory will be used to release the corresponding operator manifests via new operator metadata containers.
+
+    description: |
+      Red Hat OpenShift Container Platform is Red Hat's cloud computing Kubernetes application platform solution designed for on-premise or private cloud deployments.
+
+      This advisory will be used to release the corresponding operator manifests via new operator metadata containers.
+
+      All OpenShift Container Platform 4.3 users are advised to upgrade to these updated packages and images.
+    solution: *common_solution
+  cve:
+    synopsis: OpenShift Container Platform 4.3.z security update
+    topic: |
+      Red Hat OpenShift Container Platform release 4.3.z is now available with updates to packages and images that fix several bugs and add enhancements.
+
+      Red Hat Product Security has rated this update as having a security impact of [[Important]]. A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE link(s) in the References section.
+    description: |
+      Red Hat OpenShift Container Platform is Red Hat's cloud computing Kubernetes application platform solution designed for on-premise or private cloud deployments.
+      Security Fix(es):
+
+      [[CVEs]]
+
+      For more details about the security issue(s), including the impact, a CVSS
+      score, acknowledgments, and other related information, refer to the CVE page(s)
+      listed in the References section.
+    solution: *common_solution


### PR DESCRIPTION
In favor of https://jira.coreos.com/browse/ART-1011, configure boilerplate text in ocp-build-data for different kinds of advisories.