### PR TITLE
Add RHEL 8 fast-datapath repos

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -202,6 +202,17 @@ repos:
       default: rhel-8-for-x86_64-appstream-rpms
       ppc64le: rhel-8-for-ppc64le-appstream-rpms
       s390x: rhel-8-for-s390x-appstream-rpms
+  rhel-8-fast-datapath-rpms:
+    conf:
+      baseurl:
+        ppc64le: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/layered/rhel8/ppc64le/fast-datapath/os/
+        s390x: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/layered/rhel8/s390x/fast-datapath/os/
+        x86_64: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/layered/rhel8/x86_64/fast-datapath/os/
+    content_set:
+      default: rhel-8-for-x86_64-fast-datapath-rpms
+      ppc64le: rhel-8-for-ppc64le-fast-datapath-rpms
+      s390x: rhel-8-for-s390x-fast-datapath-rpms
+      optional: true
   openstack-beta-for-rhel-8-rpms:
     conf:
       baseurl:


### PR DESCRIPTION
Those are needed for kuryr-kubernetes to have python3-openvswitch, but
were also present for RHEL 7, so I think it isn't controversial to have
them for 8 as well.