### PR TITLE
Switch Kuryr images to RHEL8 and OSP16

### DIFF
--- a/images/kuryr-cni.yml
+++ b/images/kuryr-cni.yml
@@ -2,22 +2,22 @@ arches:
 - x86_64
 content:
   source:
-    dockerfile: openshift-kuryr-cni.Dockerfile
+    dockerfile: openshift-kuryr-cni-rhel8.Dockerfile
     git:
       branch:
         fallback: master
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift/kuryr-kubernetes.git
 enabled_repos:
-- rhel-server-rpms
-- rhel-server-optional-rpms
-- rhel-openstack-rpms
-- rhel-server-ose-rpms
-- rhel-server-ose-rpms-shipped
+- rhel-8-baseos-rpms
+- rhel-8-appstream-rpms
+- rhel-8-fast-datapath-rpms
+- openstack-16-for-rhel-8-rpms
+- rhel-8-server-ose-rpms
 from:
   builder:
   - stream: golang
-  member: openshift-enterprise-base
+  stream: rhel8
 name: openshift/ose-kuryr-cni
 owners:
 - shiftstack-team@redhat.com

--- a/images/kuryr-controller.yml
+++ b/images/kuryr-controller.yml
@@ -2,20 +2,20 @@ arches:
 - x86_64
 content:
   source:
-    dockerfile: openshift-kuryr-controller.Dockerfile
+    dockerfile: openshift-kuryr-controller-rhel8.Dockerfile
     git:
       branch:
         fallback: master
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift/kuryr-kubernetes.git
 enabled_repos:
-- rhel-server-rpms
-- rhel-server-optional-rpms
-- rhel-openstack-rpms
-- rhel-server-ose-rpms
-- rhel-server-ose-rpms-shipped
+- rhel-8-baseos-rpms
+- rhel-8-appstream-rpms
+- rhel-8-fast-datapath-rpms
+- openstack-16-for-rhel-8-rpms
+- rhel-8-server-ose-rpms
 from:
-  member: openshift-enterprise-base
+  stream: rhel8
 name: openshift/ose-kuryr-controller
 owners:
 - shiftstack-team@redhat.com

--- a/rpms/openshift-kuryr.yml
+++ b/rpms/openshift-kuryr.yml
@@ -1,7 +1,5 @@
 owners:
   - shiftstack-team@redhat.com
-enabled_repos:
-- rhel-openstack-rpms
 content:
   source:
     git:
@@ -9,5 +7,7 @@ content:
       branch:
         target: release-{MAJOR}.{MINOR}
         fallback: master
-    specfile: openshift-kuryr-kubernetes.spec
+    specfile: openshift-kuryr-kubernetes-rhel8.spec
 name: openshift-kuryr
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-8


### PR DESCRIPTION
We want Kuryr to use newer dependencies so we're switching it to use
RHEL8 and OSP16. This commit does so.