### PR TITLE
Update advisory numbers for 3.9.102

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -1,8 +1,8 @@
 advisories:
   # AWFUL HACK TO MAKE signed-compose WORK BECAUSE REAL ADVISORY ALREADY SHIPPED
   #rpm: 46117
-  rpm: 46288
-  image: 46118
+  rpm: 47924
+  image: 47925
 arches:
 - x86_64
 branch: rhaos-{MAJOR}.{MINOR}-rhel-7


### PR DESCRIPTION
Manually doing this because our Jenkins doesn't have the permission to write this repo: https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fadvisories/15/console 