### PR TITLE
Rename linuxptp-daemon image name to ptp

### DIFF
--- a/images/linuxptp-daemon.yml
+++ b/images/linuxptp-daemon.yml
@@ -18,6 +18,6 @@ from:
   builder:
   - stream: golang
   member: openshift-enterprise-base
-name: openshift/ose-linuxptp-daemon
+name: openshift/ose-ptp
 owners:
 - multus-dev@redhat.com


### PR DESCRIPTION
This is to maintain consistent image names between
Origin and OCP. Origin image is added via:
https://github.com/openshift/release/pull/5631