### PR TITLE
Build ose-cli-artifacts for non-x86 platforms as well

### DIFF
--- a/images/ose-cli-artifacts.yml
+++ b/images/ose-cli-artifacts.yml
@@ -1,5 +1,3 @@
-arches:
-- x86_64
 container_yaml:
   go:
     modules:


### PR DESCRIPTION
have seen this following error on the ppc64le platform, so including this image.

```
[root@localhost ~]# oc get pods --all-namespaces | grep download
openshift-console                                       downloads-6f7c8f7ccf-cxn4w                                             0/1     ImagePullBackOff   0          3d15h
openshift-console                                       downloads-6f7c8f7ccf-fdlbj                                             0/1     ImagePullBackOff   0          15h
```