### PR TITLE
ovn-kubernetes: add FDP Next repo and allow it for ovn-kubernetes

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -60,14 +60,14 @@ repos:
       default: rhel-7-server-ansible-2.8-rpms
       ppc64le: rhel-7-server-ansible-2.8-for-power-le-rpms
       s390x: rhel-7-server-ansible-2.8-for-system-z-rpms
-  rhel-fast-datapath-htb-rpms:
+  rhel-fast-datapath-beta-rpms:
     conf:
       baseurl:
-        ppc64le: http://pulp.dist.prod.ext.phx2.redhat.com/content/beta/rhel/power-le/7/ppc64le/fast-datapath/os/
-        s390x: http://download.lab.bos.redhat.com/rcm-guest/puddles/Multi-Arch/Fast-DataPath/Beta/latest/s390x/os/
-        x86_64: http://pulp.dist.prod.ext.phx2.redhat.com/content/htb/rhel/server/7/x86_64/fast-datapath/os/
+        ppc64le: http://download-node-02.eng.bos.redhat.com/brewroot/repos/fast-datapath-rhel-7-build/latest/ppc64le/
+        s390x: http://download-node-02.eng.bos.redhat.com/brewroot/repos/fast-datapath-rhel-7-build/latest/s390x/
+        x86_64: http://download-node-02.eng.bos.redhat.com/brewroot/repos/fast-datapath-rhel-7-build/latest/x86_64/
     content_set:
-      default: rhel-7-fast-datapath-htb-rpms
+      default: rhel-7-fast-datapath-beta-rpms
       optional: true
       ppc64le: rhel-7-for-power-le-fast-datapath-beta-rpms
       s390x: rhel-7-for-system-z-fast-datapath-beta-rpms

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -13,6 +13,7 @@ content:
 enabled_repos:
 - rhel-server-rpms
 - rhel-server-optional-rpms
+- rhel-fast-datapath-beta-rpms
 - rhel-fast-datapath-rpms
 - rhel-server-extras-rpms
 - rhel-server-ose-rpms


### PR DESCRIPTION
This will allow us to select OVS 2.12 for its RAFT HA feature.

@squeed @pecameron @danwinship 