### PR TITLE
ose-containernetworking-plugins: Adds rhel-8-golang as an image stream

### DIFF
--- a/images/ose-containernetworking-plugins.yml
+++ b/images/ose-containernetworking-plugins.yml
@@ -15,6 +15,7 @@ enabled_repos:
 - rhel-server-optional-rpms
 from:
   builder:
+  - stream: rhel-8-golang
   - stream: golang
   member: openshift-enterprise-base
 name: openshift/ose-container-networking-plugins


### PR DESCRIPTION
Has been failing Dockerfile reconcilation due to a miscount of image parents.

Source Dockerfile @ https://github.com/openshift/containernetworking-plugins/blob/master/Dockerfile