### PR TITLE
4.3: Enable kuryr on ppc64le

### DIFF
--- a/images/kuryr-cni.yml
+++ b/images/kuryr-cni.yml
@@ -1,5 +1,6 @@
 arches:
 - x86_64
+- ppc64le
 content:
   source:
     dockerfile: openshift-kuryr-cni-rhel8.Dockerfile

--- a/images/kuryr-controller.yml
+++ b/images/kuryr-controller.yml
@@ -1,5 +1,6 @@
 arches:
 - x86_64
+- ppc64le
 content:
   source:
     dockerfile: openshift-kuryr-controller-rhel8.Dockerfile


### PR DESCRIPTION
Kuryr is being ported to Power LE in RHOS 16.

CC: @sosiouxme 