### PR TITLE
[Openshift-4.4] Multus CNI should be built from two streams

### DIFF
--- a/images/multus-cni.yml
+++ b/images/multus-cni.yml
@@ -18,6 +18,7 @@ enabled_repos:
 - rhel-server-rh-common-rpms
 from:
   builder:
+  - stream: rhel-8-golang
   - stream: golang
   member: openshift-enterprise-base
 labels:


### PR DESCRIPTION
Including the `rhel-8-golang` stream.