### PR TITLE
[ART-1255] Unified controller+node into single sdn image

### DIFF
--- a/images/ose-sdn.yml
+++ b/images/ose-sdn.yml
@@ -1,11 +1,10 @@
-# this is same as openshift-enterprise-node.yml
 container_yaml:
   go:
     modules:
     - module: github.com/openshift/sdn
 content:
   source:
-    dockerfile: images/node/Dockerfile.rhel
+    dockerfile: images/sdn/Dockerfile.rhel
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
@@ -23,6 +22,6 @@ from:
   builder:
   - stream: golang
   member: openshift-enterprise-base
-name: openshift/ose-node
+name: openshift/ose-sdn
 owners:
 - mfojtik@redhat.com


### PR DESCRIPTION
[ART-1255](https://jira.coreos.com/browse/ART-1255) to reflect upstream changes made in:
- https://github.com/openshift/release/pull/5725/files
- https://github.com/openshift/release/pull/5904/files

`openshift-enterprise-node.yml` was already removed from `openshift-4.3` branch, in commit fce03732d8084ece068612d4b4aac0ef0e9a8cd2.

I'm currently running a [custom build](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fcustom/780/console), ~will update the description with the brew link as it becomes available.~
https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=24702672

Not sure if component name should change as well, but I couldn't find any of the obvious names using `brew list-pkgs` ...
```
distgit:
  component: ose-node-container
```