### PR TITLE
Revert "Update advisories on group.yml"

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -10,10 +10,10 @@ arches:
 operator_image_ref_mode: by-arch
 
 advisories:
-  image: 49287
-  rpm: 49286
-  extras: 49288
-  metadata: 49289
+  image: 48931
+  rpm: 48930
+  extras: 48932
+  metadata: 48933
   # security:
 
 branch: rhaos-{MAJOR}.{MINOR}-rhel-7


### PR DESCRIPTION
This reverts commit 78a540d788fa4ac68d87f73a55c1136dc53615bf.
To rebuild 4.2.10 signed compose.