### PR TITLE
Add builder for ironic image

### DIFF
--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -17,6 +17,8 @@ enabled_repos:
 - openstack-16-for-rhel-8-rpms
 - rhel-8-server-ose-rpms
 from:
+  builder:
+  - stream: rhel
   stream: rhel8
 name: openshift/ose-ironic
 owners:


### PR DESCRIPTION
This should hopefully fix the issue:
FAILURE: Error reconciling Dockerfile for openshift/ose-ironic in OCP v4.4