### PR TITLE
Enable ose-metering-helm on all arches

### DIFF
--- a/images/ose-metering-helm.yml
+++ b/images/ose-metering-helm.yml
@@ -22,5 +22,3 @@ owners:
 - sd-operator-metering@redhat.com
 dependents:
 - ose-metering-ansible-operator
-arches:
-  - x86_64


### PR DESCRIPTION
https://github.com/operator-framework/helm/pull/10 fixed the build itself.

We will want this cherry-picked to at least 4.3 once the build fix is cherry-picked there.