### PR TITLE
Remove OpenStack repos from Kuryr builds

### DIFF
--- a/images/kuryr-cni.yml
+++ b/images/kuryr-cni.yml
@@ -15,7 +15,6 @@ enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
 - rhel-8-fast-datapath-rpms
-- openstack-16-for-rhel-8-rpms
 - rhel-8-server-ose-rpms
 from:
   builder:

--- a/images/kuryr-controller.yml
+++ b/images/kuryr-controller.yml
@@ -15,7 +15,6 @@ enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
 - rhel-8-fast-datapath-rpms
-- openstack-16-for-rhel-8-rpms
 - rhel-8-server-ose-rpms
 from:
   stream: rhel8


### PR DESCRIPTION
All the Kuryr dependencies are now tagged into OCP repos, so we can
remove OpenStack deps from Kuryr builds.