### PR TITLE
Revert: Rename ironic-rhcos to ironic-machine-os in 4.2

### DIFF
--- a/images/ironic-rhcos-downloader.yml
+++ b/images/ironic-rhcos-downloader.yml
@@ -17,6 +17,6 @@ enabled_repos:
 - openstack-15-for-rhel-8-rpms
 from:
   stream: rhel8
-name: openshift/ose-ironic-machine-os-downloader
+name: openshift/ose-ironic-rhcos-downloader
 owners:
 - ironic-osp-owners@redhat.com


### PR DESCRIPTION
Revert renaming ironic-rhcos iamge in 4.2 release.
This was supposed to happen from 4.3 and forward.