### PR TITLE
Revert ovs from beta

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -67,14 +67,14 @@ repos:
       default: rhel-7-server-ansible-2.8-rpms
       ppc64le: rhel-7-server-ansible-2.8-for-power-le-rpms
       s390x: rhel-7-server-ansible-2.8-for-system-z-rpms
-  rhel-fast-datapath-beta-rpms:
+  rhel-fast-datapath-htb-rpms:
     conf:
       baseurl:
-        ppc64le: http://download-node-02.eng.bos.redhat.com/brewroot/repos/fast-datapath-rhel-7-build/latest/ppc64le/
-        s390x: http://download-node-02.eng.bos.redhat.com/brewroot/repos/fast-datapath-rhel-7-build/latest/s390x/
-        x86_64: http://download-node-02.eng.bos.redhat.com/brewroot/repos/fast-datapath-rhel-7-build/latest/x86_64/
+        ppc64le: http://pulp.dist.prod.ext.phx2.redhat.com/content/beta/rhel/power-le/7/ppc64le/fast-datapath/os/
+        s390x: http://download.lab.bos.redhat.com/rcm-guest/puddles/Multi-Arch/Fast-DataPath/Beta/latest/s390x/os/
+        x86_64: http://pulp.dist.prod.ext.phx2.redhat.com/content/htb/rhel/server/7/x86_64/fast-datapath/os/
     content_set:
-      default: rhel-7-fast-datapath-beta-rpms
+      default: rhel-7-fast-datapath-htb-rpms
       optional: true
       ppc64le: rhel-7-for-power-le-fast-datapath-beta-rpms
       s390x: rhel-7-for-system-z-fast-datapath-beta-rpms

--- a/group.yml
+++ b/group.yml
@@ -76,8 +76,8 @@ repos:
     content_set:
       default: rhel-7-fast-datapath-htb-rpms
       optional: true
-      ppc64le: rhel-7-for-power-le-fast-datapath-beta-rpms
-      s390x: rhel-7-for-system-z-fast-datapath-beta-rpms
+      ppc64le: rhel-7-for-power-le-fast-datapath-htb-rpms
+      s390x: rhel-7-for-system-z-fast-datapath-htb-rpms
   rhel-fast-datapath-rpms:
     conf:
       baseurl:

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -13,7 +13,6 @@ content:
 enabled_repos:
 - rhel-server-rpms
 - rhel-server-optional-rpms
-- rhel-fast-datapath-beta-rpms
 - rhel-fast-datapath-rpms
 - rhel-server-extras-rpms
 - rhel-server-ose-rpms


### PR DESCRIPTION
ovs2.12 is now GA and available in the usual fastdatapath repos.
This reverts PR 202 that gets ovs2.12 from the beta repos

SDN-736 [ovn] revert hardcoded OVS/OVN version hacks
https://issues.redhat.com/browse/SDN-736

Signed-off-by: Phil Cameron <pcameron@redhat.com>