### PR TITLE
Enable ODCS for image build

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -1,3 +1,11 @@
+# switches for experimental Doozer features
+doozer_feature_gates:
+  # odcs_enabled: whether to enable Doozer ODCS support (without explicitly specifying --odcs-mode option)
+  # See https://issues.redhat.com/browse/ART-128 for more information about ODCS mode.
+  odcs_enabled: true
+  # odcs_aggressive: true to build an image with ODCS auto mode even if its image config doesn't have `odcs` field defined
+  odcs_aggressive: true
+
 advisories:
   rpm: 49981
   image: 49982


### PR DESCRIPTION
Turn on `odcs_enabled` and `odcs_aggressive` feature gate so that future 3.11 image build will use ODCS composes.
Requires https://github.com/openshift/doozer/pull/158 to be landed.