### PR TITLE
Ironic images should not use osp repos

### DIFF
--- a/images/ironic-hardware-inventory-recorder-image.yml
+++ b/images/ironic-hardware-inventory-recorder-image.yml
@@ -18,7 +18,6 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- openstack-16-for-rhel-8-rpms
 - rhel-8-server-ose-rpms
 from:
   stream: rhel8

--- a/images/ironic-inspector.yml
+++ b/images/ironic-inspector.yml
@@ -14,7 +14,6 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- openstack-16-for-rhel-8-rpms
 - rhel-8-server-ose-rpms
 from:
   stream: rhel8

--- a/images/ironic-rhcos-downloader.yml
+++ b/images/ironic-rhcos-downloader.yml
@@ -14,7 +14,6 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- openstack-16-for-rhel-8-rpms
 - rhel-8-server-ose-rpms
 from:
   stream: rhel8

--- a/images/ironic-static-ip-manager.yml
+++ b/images/ironic-static-ip-manager.yml
@@ -14,7 +14,6 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- openstack-16-for-rhel-8-rpms
 - rhel-8-server-ose-rpms
 from:
   stream: rhel8

--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -14,7 +14,6 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- openstack-16-for-rhel-8-rpms
 - rhel-8-server-ose-rpms
 from:
   builder:


### PR DESCRIPTION
Removing osp 16 repo dependency from ironic images.
Excluding ipa-downloader until [0] is merged.

[0] https://github.com/openshift/release/pull/6528