### PR TITLE
[ART-1422] Disable kube-storage-version-migrator

### DIFF
--- a/images/ose-kube-storage-version-migrator.yml
+++ b/images/ose-kube-storage-version-migrator.yml
@@ -1,3 +1,4 @@
+mode: disabled
 container_yaml:
   go:
     modules:


### PR DESCRIPTION
Not enabled in openshift-4.3.