### PR TITLE
4.4: Sanitize storage image owners

### DIFF
--- a/images/cluster-storage-operator.yml
+++ b/images/cluster-storage-operator.yml
@@ -20,4 +20,4 @@ from:
   member: openshift-enterprise-base
 name: openshift/ose-cluster-storage-operator
 owners:
-- mawong@redhat.com
+- aos-storage-staff@redhat.com

--- a/images/csi-attacher.yml
+++ b/images/csi-attacher.yml
@@ -26,4 +26,4 @@ labels:
   vendor: Red Hat
 name: openshift/ose-csi-external-attacher
 owners:
-- jsafrane@redhat.com
+- aos-storage-staff@redhat.com

--- a/images/csi-livenessprobe.yml
+++ b/images/csi-livenessprobe.yml
@@ -26,4 +26,4 @@ labels:
   vendor: Red Hat
 name: openshift/ose-csi-livenessprobe
 owners:
-- jsafrane@redhat.com
+- aos-storage-staff@redhat.com

--- a/images/csi-provisioner.yml
+++ b/images/csi-provisioner.yml
@@ -26,4 +26,4 @@ labels:
   vendor: Red Hat
 name: openshift/ose-csi-external-provisioner
 owners:
-- jsafrane@redhat.com
+- aos-storage-staff@redhat.com

--- a/images/efs-provisioner.yml
+++ b/images/efs-provisioner.yml
@@ -19,4 +19,4 @@ from:
   member: openshift-enterprise-base
 name: openshift/ose-efs-provisioner
 owners:
-- mawong@redhat.com
+- aos-storage-staff@redhat.com

--- a/images/local-storage-diskmaker.yml
+++ b/images/local-storage-diskmaker.yml
@@ -19,7 +19,7 @@ from:
   member: openshift-enterprise-base
 name: openshift/ose-local-storage-diskmaker
 owners:
-- aos-storage-devel@redhat.com
+- aos-storage-staff@redhat.com
 dependents:
   - local-storage-operator
 

--- a/images/local-storage-operator.yml
+++ b/images/local-storage-operator.yml
@@ -19,7 +19,7 @@ from:
   member: openshift-enterprise-base
 name: openshift/ose-local-storage-operator
 owners:
-- aos-storage-devel@redhat.com
+- aos-storage-staff@redhat.com
 update-csv:
   manifests-dir: manifests
   registry: image-registry.openshift-image-registry.svc:5000

--- a/images/local-storage-static-provisioner.yml
+++ b/images/local-storage-static-provisioner.yml
@@ -19,6 +19,6 @@ from:
   member: openshift-enterprise-base
 name: openshift/ose-local-storage-static-provisioner
 owners:
-- aos-storage-devel@redhat.com
+- aos-storage-staff@redhat.com
 dependents:
   - local-storage-operator

--- a/images/openshift-enterprise-recycler.yml
+++ b/images/openshift-enterprise-recycler.yml
@@ -20,4 +20,4 @@ labels:
   vendor: Red Hat
 name: openshift/ose-recycler
 owners:
-- aos-storage-devel@redhat.com
+- aos-storage-staff@redhat.com


### PR DESCRIPTION
All storage images should be owned by aos-storage-staff mailing list.
For example:
* `mawong@redhat.com` has left the company. 
* `aos-storage-devel` is not really used.

I will cherry-pick into all 4.x when this gets merged.