### PR TITLE
Change oauth-proxy Dockerfile path

### DIFF
--- a/images/golang-github-openshift-oauth-proxy.yml
+++ b/images/golang-github-openshift-oauth-proxy.yml
@@ -5,7 +5,6 @@ content:
         fallback: master
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift/oauth-proxy.git
-    path: images
     modifications:
     - action: add
       source: https://gitlab.cee.redhat.com/aosqe/ocp-build-data-gating/raw/master/openshift-{MAJOR}.{MINOR}/golang-github-openshift-oauth-proxy/gating_yaml


### PR DESCRIPTION
https://github.com/openshift/oauth-proxy/pull/135 moved Dockerfile
from images subdirectory to project root.