### PR TITLE
The ironic-ipa-downloader image should not use osp repos

### DIFF
--- a/images/ironic-ipa-downloader.yml
+++ b/images/ironic-ipa-downloader.yml
@@ -14,7 +14,6 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- openstack-16-for-rhel-8-rpms
 - rhel-8-server-ose-rpms
 from:
   stream: rhel8


### PR DESCRIPTION
We have all the packages tagged, we can remove the reference from
the ipa-downloader image.