### PR TITLE
Renames route-override-cni and whereabouts-cni to follow naming conventions

### DIFF
--- a/images/ose-multus-route-override-cni.yml
+++ b/images/ose-multus-route-override-cni.yml
@@ -15,6 +15,6 @@ from:
   - stream: golang
   - stream: rhel-8-golang
   stream: rhel
-name: openshift/ose-route-override-cni
+name: openshift/ose-multus-route-override-cni
 owners:
 - multus-dev@redhat.com

--- a/images/ose-multus-whereabouts-ipam-cni.yml
+++ b/images/ose-multus-whereabouts-ipam-cni.yml
@@ -15,6 +15,6 @@ from:
   - stream: golang
   - stream: rhel-8-golang
   stream: rhel
-name: openshift/ose-whereabouts-cni
+name: openshift/ose-multus-whereabouts-ipam-cni
 owners:
 - multus-dev@redhat.com


### PR DESCRIPTION
It was discovered that these image names didn't meet conventions. I renamed the files to match the image names, and updated the image names.

Related to #287 