### PR TITLE
Bug 1798086: Re-enable the TSB and its operator

### DIFF
--- a/images/openshift-enterprise-template-service-broker-operator.yml
+++ b/images/openshift-enterprise-template-service-broker-operator.yml
@@ -1,0 +1,21 @@
+content:
+  source:
+    dockerfile: build/Dockerfile
+    git:
+      branch:
+        fallback: master
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift/template-service-broker-operator.git
+enabled_repos:
+- rhel-server-rpms
+- rhel-server-optional-rpms
+from:
+  member: openshift-enterprise-ansible-operator
+name: openshift/ose-template-service-broker-operator
+owners:
+- ccpeng-team@redhat.com
+- jmontleo@redhat.com
+update-csv:
+  manifests-dir: deploy/olm-catalog/openshift-template-service-broker-manifests/
+  registry: image-registry.openshift-image-registry.svc:5000
+mode: disabled

--- a/images/template-service-broker.yml
+++ b/images/template-service-broker.yml
@@ -11,6 +11,8 @@ content:
         fallback: master
         target: release-{MAJOR}.{MINOR}
       url: https://github.com/openshift/template-service-broker.git
+dependents:
+- openshift-enterprise-template-service-broker-operator
 enabled_repos:
 - rhel-server-rpms
 - rhel-server-optional-rpms

--- a/images/template-service-broker.yml
+++ b/images/template-service-broker.yml
@@ -1,0 +1,32 @@
+container_yaml:
+  go:
+    modules:
+    - module: github.com/openshift/template-service-broker
+content:
+  source:
+    alias: ose
+    dockerfile: images/Dockerfile.rhel
+    git:
+      branch:
+        fallback: master
+        target: release-{MAJOR}.{MINOR}
+      url: https://github.com/openshift/template-service-broker.git
+enabled_repos:
+- rhel-server-rpms
+- rhel-server-optional-rpms
+- rhel-server-ose-rpms
+from:
+  builder:
+  - stream: golang
+  member: openshift-enterprise-base
+labels:
+  License: GPLv2+
+  io.k8s.description: Template Service Broker
+  io.k8s.display-name: Template Service Broker
+  vendor: Red Hat
+name: openshift/ose-template-service-broker
+owners:
+- aos-operator-sdk@redhat.com
+- jesusr@redhat.com
+- jlanford@redhat.com
+- fabian@redhat.com


### PR DESCRIPTION
The Service Catalog removal job did not make it in for feature freeze because of some late bugs found with the Job and CVO. So we need to re-enable the Template Service Broker and its Operator for OpenShift 4.4. The Ansible Service Broker and its Operator will not be re-enabled and should remain disabled.