### PR TITLE
Update info for descheduler and descheduler-operator

### DIFF
--- a/images/atomic-openshift-descheduler.yml
+++ b/images/atomic-openshift-descheduler.yml
@@ -1,7 +1,7 @@
 container_yaml:
   go:
     modules:
-    - module: github.com/kubernetes-incubator/descheduler
+    - module: sigs.k8s.io/descheduler
 content:
   source:
     dockerfile: images/descheduler/Dockerfile.rhel7
@@ -26,3 +26,4 @@ labels:
 name: openshift/ose-descheduler
 owners:
 - rgudimet@redhat.com
+- aos-workloads@redhat.com

--- a/images/descheduler-operator.yml
+++ b/images/descheduler-operator.yml
@@ -1,14 +1,14 @@
 container_yaml:
   go:
     modules:
-    - module: github.com/openshift/descheduler-operator
+    - module: github.com/openshift/cluster-kube-descheduler-operator
 content:
   source:
     dockerfile: Dockerfile.rhel7
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
-      url: git@github.com:openshift/descheduler-operator.git
+      url: git@github.com:openshift/cluster-kube-descheduler-operator.git
 enabled_repos:
 - rhel-server-rpms
 - rhel-server-optional-rpms
@@ -16,6 +16,6 @@ from:
   builder:
   - stream: golang
   member: openshift-enterprise-base
-name: openshift/ose-descheduler-operator
+name: openshift/ose-cluster-kube-descheduler-operator
 owners:
-- aos-pod@redhat.com
+- aos-workloads@redhat.com


### PR DESCRIPTION
Changes:
* the descheduler repo has changed, and the module should be updated to reflect that
* the descheduler dockerfile has changed
* descheduler-operator repo has changed
* descheduler and descheduler-operator owners updated to reflect that this project is now under the workloads team

If possible, it would be nice to get this in to 4.4 as well