### PR TITLE
Remove template-service-broker-operator from dependent list

### DIFF
--- a/images/openshift-enterprise-template-service-broker-operator.yml
+++ b/images/openshift-enterprise-template-service-broker-operator.yml
@@ -18,4 +18,5 @@ owners:
 update-csv:
   manifests-dir: deploy/olm-catalog/openshift-template-service-broker-manifests/
   registry: image-registry.openshift-image-registry.svc:5000
+# When enabling this, remember to add this image as a dependent of template-service-broker.
 mode: disabled

--- a/images/template-service-broker.yml
+++ b/images/template-service-broker.yml
@@ -11,8 +11,9 @@ content:
         fallback: master
         target: release-{MAJOR}.{MINOR}
       url: https://github.com/openshift/template-service-broker.git
-dependents:
-- openshift-enterprise-template-service-broker-operator
+# disable this until openshift-enterprise-template-service-broker-operator is enabled
+# dependents:
+# - openshift-enterprise-template-service-broker-operator
 enabled_repos:
 - rhel-server-rpms
 - rhel-server-optional-rpms


### PR DESCRIPTION
Current Doozer version treats images in the dependent list as enabled images.
Need to disable it to make doozer happy until the disabled image is ready to build.