### PR TITLE
Fix up owners of networking images

### DIFF
--- a/images/cluster-network-operator.yml
+++ b/images/cluster-network-operator.yml
@@ -18,4 +18,4 @@ from:
   member: openshift-enterprise-base
 name: openshift/ose-cluster-network-operator
 owners:
-- atomic-networking@redhat.com
+- aos-networking-staff@redhat.com

--- a/images/kube-proxy.yml
+++ b/images/kube-proxy.yml
@@ -18,6 +18,4 @@ from:
   member: openshift-enterprise-base
 name: openshift/ose-kube-proxy
 owners:
-- pcameron@redhat.com
-- cdc@redhat.com
-- dcbw@redhat.com
+- aos-networking-staff@redhat.com

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -29,5 +29,4 @@ labels:
   vendor: Red Hat
 name: openshift/ose-ovn-kubernetes
 owners:
-- pcameron@redhat.com
-- dcbw@redhat.com
+- aos-networking-staff@redhat.com

--- a/images/ose-sdn.yml
+++ b/images/ose-sdn.yml
@@ -23,4 +23,4 @@ from:
   member: openshift-enterprise-base
 name: openshift/ose-sdn
 owners:
-- aos-sdn-staff@redhat.com
+- aos-networking-staff@redhat.com


### PR DESCRIPTION
The sdn image is currently owned by `aos-sdn-staff`, which AFAICT is not a real list. (It exists but appears to have no members.) The real team list is `aos-networking-staff`.

cluster-networking-operator is owned by `atomic-networking`, which does exist, but goes to lots of irrelevant people in addition to the relevant ones.

kube-proxy and ovn-kubernetes are currently owned by individuals, and it would make more sense to have them owned by the list as well. I'll cc those individuals here (@pecameron @dcbw @squeed) to give them a chance to object, except that they won't because one of them is on PTO and one is on paternity leave, which is exactly the reason we shouldn't have individuals as owners...

This should be cherry-picked as far back as it can go