### PR TITLE
Eliminate tito use for 4.4

### DIFF
--- a/rpms/openshift.yml
+++ b/rpms/openshift.yml
@@ -3,7 +3,7 @@ content:
     alias: ose
     specfile: origin.spec
   build:
-    use_source_tito_config: true
+    use_source_tito_config: false
     tito_target: aos-{MAJOR}.{MINOR}
     # Address https://coreos.slack.com/archives/GDBRP5YJH/p1573497720048000 before turning to false
     push_release_commit: true


### PR DESCRIPTION
Working to satisfy https://issues.redhat.com/browse/ART-1550 . Moving away from custom tito logic with 4.4 as the first test bed.