### PR TITLE
Revert "Update advisories on group.yml"

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -1,4 +1,4 @@
-freeze_automation: no
+freeze_automation: scheduled
 
 vars:
   MAJOR: 4
@@ -12,21 +12,21 @@ arches:
 operator_image_ref_mode: by-arch
 
 advisories:
-  image: 51997
-  rpm: 51996
-  extras: 51998
-  metadata: 51999
+  image: 51758
+  rpm: 51757
+  extras: 51759
+  metadata: 51760
   # security:
 
 build_profiles:
-  image: 51997
+  image:
     unsigned:
       signing_intent: unsigned
       repo_type: unsigned
     signed:
       signing_intent: release
       repo_type: signed
-  rpm: 51996
+  rpm:
     default:
       targets:
       - rhaos-{MAJOR}.{MINOR}-rhel-7-candidate


### PR DESCRIPTION
This reverts commit b7a24fcf4a7753b1d16b71980def8e5592362a36.

https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fadvisories/62/console is buggy to update group.yml because it uses text-based processing.