### PR TITLE
ART-1559 [4.5] - Get OLM operator owners to update their CSV channels

### DIFF
--- a/images/cluster-logging-operator.yml
+++ b/images/cluster-logging-operator.yml
@@ -1,3 +1,4 @@
+mode: disabled
 container_yaml:
   go:
     modules:

--- a/images/cluster-nfd-operator.yml
+++ b/images/cluster-nfd-operator.yml
@@ -1,3 +1,4 @@
+mode: disabled
 container_yaml:
   go:
     modules:

--- a/images/clusterresourceoverride-operator.yml
+++ b/images/clusterresourceoverride-operator.yml
@@ -1,3 +1,4 @@
+mode: disabled
 container_yaml:
   go:
     modules:

--- a/images/local-storage-operator.yml
+++ b/images/local-storage-operator.yml
@@ -1,3 +1,4 @@
+mode: disabled
 container_yaml:
   go:
     modules:

--- a/images/ptp-operator.yml
+++ b/images/ptp-operator.yml
@@ -1,3 +1,4 @@
+mode: disabled
 container_yaml:
   go:
     modules:


### PR DESCRIPTION
Disable operators which do not have 4.5 references in their package
files so that our builds don't crash. Revert each as they are fixed
upstream.

ART JIRA: https://issues.redhat.com/browse/ART-1559

Individual Request PRs:

* https://github.com/openshift/ptp-operator/issues/38
* https://github.com/openshift/local-storage-operator/issues/94
* https://github.com/openshift/cluster-resource-override-admission-operator/issues/25
* https://github.com/openshift/cluster-nfd-operator/issues/71
* https://github.com/openshift/cluster-logging-operator/issues/387