### PR TITLE
Fix up owners of networking images [4.2]

### DIFF
--- a/images/cluster-network-operator.yml
+++ b/images/cluster-network-operator.yml
@@ -18,4 +18,4 @@ from:
   member: openshift-enterprise-base
 name: openshift/ose-cluster-network-operator
 owners:
-- atomic-networking@redhat.com
+- aos-networking-staff@redhat.com

--- a/images/kube-proxy.yml
+++ b/images/kube-proxy.yml
@@ -18,6 +18,4 @@ from:
   member: openshift-enterprise-base
 name: openshift/ose-kube-proxy
 owners:
-- pcameron@redhat.com
-- cdc@redhat.com
-- dcbw@redhat.com
+- aos-networking-staff@redhat.com

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -29,5 +29,4 @@ labels:
   vendor: Red Hat
 name: openshift/ose-ovn-kubernetes
 owners:
-- pcameron@redhat.com
-- dcbw@redhat.com
+- aos-networking-staff@redhat.com

--- a/images/ose-sdn.yml
+++ b/images/ose-sdn.yml
@@ -24,4 +24,4 @@ from:
   member: openshift-enterprise-base
 name: openshift/ose-node
 owners:
-- mfojtik@redhat.com
+- aos-networking-staff@redhat.com


### PR DESCRIPTION
Backport of #323 to openshift-4.2. Only change is that previously ose-sdn was owned by @mfojtik here, which is just because he's the one who originally split sdn out of origin, but it doesn't make sense for him to be the owner now.