### PR TITLE
Fix up owners of networking images [4.1]

### DIFF
--- a/images/cluster-network-operator.yml
+++ b/images/cluster-network-operator.yml
@@ -15,4 +15,4 @@ from:
   member: openshift-enterprise-base
 name: openshift/ose-cluster-network-operator
 owners:
-- atomic-networking@redhat.com
+- aos-networking-staff@redhat.com

--- a/images/kube-proxy.yml
+++ b/images/kube-proxy.yml
@@ -11,6 +11,4 @@ from:
   member: openshift-enterprise-hyperkube
 name: openshift/ose-kube-proxy
 owners:
-- pcameron@redhat.com
-- cdc@redhat.com
-- dcbw@redhat.com
+- aos-networking-staff@redhat.com

--- a/images/openshift-enterprise-node.yml
+++ b/images/openshift-enterprise-node.yml
@@ -23,4 +23,4 @@ labels:
   vendor: Red Hat
 name: openshift/ose-node
 owners:
-- aos-pod@redhat.com
+- aos-networking-staff@redhat.com

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -27,5 +27,4 @@ labels:
   vendor: Red Hat
 name: openshift/ose-ovn-kubernetes
 owners:
-- pcameron@redhat.com
-- dcbw@redhat.com
+- aos-networking-staff@redhat.com


### PR DESCRIPTION
Backport of #323 to openshift-4.1. This was before sdn was split out of origin, and the image is still defined in a file called "`images/openshift-enterprise-node.yml`" here for historical reasons, but it is actually just the SDN image, as seen by the `dockerfile: images/sdn/Dockerfile.rhel`, with the "node" image being `images/openshift-enterprise/hyperkube.yml`