### PR TITLE
Update ansible-operator base image

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -72,6 +72,18 @@ sources:
     branch:
       target: enterprise-{MAJOR}.{MINOR}
 repos:
+  rhel-7-server-ansible-2.9-rpms:
+    conf:
+      baseurl:
+        ppc64le: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/power-le/7/7Server/ppc64le/ansible/2.9/os/
+        s390x: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/system-z/7/7Server/s390x/ansible/2.9/os/
+        x86_64: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/ansible/2.9/os/
+    content_set:
+      default: rhel-7-server-ansible-2.9-rpms
+      ppc64le: rhel-7-server-ansible-2.9-for-power-le-rpms
+      s390x: rhel-7-server-ansible-2.9-for-system-z-rpms
+    reposync:
+      enabled: false
   rhel-7-server-ansible-2.8-rpms:
     conf:
       baseurl:

--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -4,7 +4,7 @@ container_yaml:
     - module: github.com/operator-framework/operator-sdk
 content:
   source:
-    release/ansible/Dockerfile
+    dockerfile: release/ansible/Dockerfile
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
@@ -14,7 +14,7 @@ enabled_repos:
 - rhel-server-optional-rpms
 - rhel-server-ose-rpms
 - rhel-server-extras-rpms
-- rhel-7-server-ansible-2.8-rpms
+- rhel-7-server-ansible-2.9-rpms
 from:
   builder:
   - stream: golang

--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -4,6 +4,7 @@ container_yaml:
     - module: github.com/operator-framework/operator-sdk
 content:
   source:
+    release/ansible/Dockerfile
     git:
       branch:
         target: release-{MAJOR}.{MINOR}


### PR DESCRIPTION
- Update Dockerfile location
- Update to ansible-2.9 RPMs which are required for proper collection support

Depends on https://github.com/openshift/ocp-release-operator-sdk/pull/46