### PR TITLE
bug 1810977: Change owners of cluster-capacity image

### DIFF
--- a/images/openshift-enterprise-cluster-capacity.yml
+++ b/images/openshift-enterprise-cluster-capacity.yml
@@ -26,4 +26,5 @@ labels:
   vendor: Red Hat
 name: openshift/ose-cluster-capacity
 owners:
-- avagarwa@redhat.com
+- jchaloup@redhat.com
+- aos-workloads@redhat.com


### PR DESCRIPTION
Cluster-capacity is now owned by workloads team

4.5: https://github.com/openshift/ocp-build-data/pull/359