### PR TITLE
Change owners of cluster-capacity image

### DIFF
--- a/images/openshift-enterprise-cluster-capacity.yml
+++ b/images/openshift-enterprise-cluster-capacity.yml
@@ -24,4 +24,5 @@ labels:
   vendor: Red Hat
 name: openshift/ose-cluster-capacity
 owners:
-- avagarwa@redhat.com
+- jchaloup@redhat.com
+- aos-workloads@redhat.com


### PR DESCRIPTION
Cluster-capacity is now owned by workloads team