### PR TITLE
Change owners of cluster-capacity image

### DIFF
--- a/images/openshift-enterprise-cluster-capacity.yml
+++ b/images/openshift-enterprise-cluster-capacity.yml
@@ -27,4 +27,5 @@ labels:
   vendor: Red Hat
 name: openshift3/ose-cluster-capacity
 owners:
-- avagarwa@redhat.com
+- jchaloup@redhat.com
+- aos-workloads@redhat.com


### PR DESCRIPTION
Cluster-capacity is now owned by workloads team