### PR TITLE
Disable ppc64le build for ose-ovn-kubernetes

### DIFF
--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -31,3 +31,6 @@ labels:
 name: openshift/ose-ovn-kubernetes
 owners:
 - aos-networking-staff@redhat.com
+arches:
+- x86_64
+- s390x


### PR DESCRIPTION
ose-ovn-kubernetes is failed with Error in plugin compare_components: Failed component comparison for components: openvswitch2.12, openvswitch2.12-devel. OSBS build id: ose-ovn-kubernetes-rhaos-44-rhel-7-4cf91-218 : https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=27163307.
I didn’t met this issue before. It looks like related to openvswitch2.12 and openvswitch2.12-devel for ppc64le. Let's temporarily disable ppc64le on it.