### PR TITLE
Disable logging components for 4.5

### DIFF
--- a/images/logging-elasticsearch5.yml
+++ b/images/logging-elasticsearch5.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   source:
     dockerfile: Dockerfile

--- a/images/logging-kibana5.yml
+++ b/images/logging-kibana5.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   source:
     dockerfile: Dockerfile


### PR DESCRIPTION
Per request of @jcantrill we are disabling these components for 4.5 for the indefinite future.

Slack conversation record: https://coreos.slack.com/archives/CB95J6R4N/p1584109467133300