### PR TITLE
Add rhel-server-ose repo to baremetal-installer

### DIFF
--- a/images/ose-baremetal-installer.yml
+++ b/images/ose-baremetal-installer.yml
@@ -12,6 +12,7 @@ content:
 enabled_repos:
 - rhel-server-rpms
 - rhel-server-optional-rpms
+- rhel-server-ose-rpms
 from:
   builder:
   - stream: golang


### PR DESCRIPTION
This is needed for packages like jq that are tagged for ocp only.