### PR TITLE
Remove rhel-8 brew tags from 3.11

### DIFF
--- a/erratatool.yml
+++ b/erratatool.yml
@@ -5,7 +5,6 @@ product: "RHOSE"
 
 brew_tag_product_version_mapping:
   rhaos-{MAJOR}.{MINOR}-rhel-7-candidate: RHEL-7-OSE-{MAJOR}.{MINOR}
-  rhaos-{MAJOR}.{MINOR}-rhel-8-candidate: OSE-{MAJOR}.{MINOR}-RHEL-8
 
 release: "RHOSE ASYNC"
 


### PR DESCRIPTION
Pruning unused rhel-8 for 3.11 to prevent the [following error](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fsweep/8127/console) from happening:

```
elliott -g openshift-3.11 find-builds -k rpm --use-default-advisory rpm
[Pipeline] sh
+ set +x
2020-03-30 13:24:49,282 INFO Cloning config data from https://github.com/openshift/ocp-build-data.git
2020-03-30 13:24:50,086 INFO Using branch from group.yml: rhaos-3.11-rhel-7
Default advisory detected: 53185
Generating list of rpms: Hold on a moment, fetching Brew builds
Gathering additional information: Brew buildinfo is required to continue
[******************]
Traceback (most recent call last):
  File "/home/jenkins/.local/lib/python3.6/site-packages/koji/__init__.py", line 2683, in _callMethod
    return self._sendCall(handler, headers, request)
  File "/home/jenkins/.local/lib/python3.6/site-packages/koji/__init__.py", line 2601, in _sendCall
    return self._sendOneCall(handler, headers, request)
  File "/home/jenkins/.local/lib/python3.6/site-packages/koji/__init__.py", line 2647, in _sendOneCall
    ret = self._read_xmlrpc_response(r)
  File "/home/jenkins/.local/lib/python3.6/site-packages/koji/__init__.py", line 2659, in _read_xmlrpc_response
    result = u.close()
  File "/usr/lib64/python3.6/xmlrpc/client.py", line 656, in close
    raise Fault(**self._stack[0])
xmlrpc.client.Fault: <Fault 1000: "Invalid tagInfo: 'rhaos-3.11-rhel-8-candidate'">

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/jenkins/.local/bin/elliott", line 11, in <module>
    load_entry_point('rh-elliott==1.0.3', 'console_scripts', 'elliott')()
  File "/home/jenkins/.local/lib/python3.6/site-packages/elliottlib/cli/__main__.py", line 902, in main
    cli(obj={})
  File "/home/jenkins/.local/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/jenkins/.local/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/jenkins/.local/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/jenkins/.local/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/jenkins/.local/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/jenkins/.local/lib/python3.6/site-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/jenkins/.local/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/jenkins/.local/lib/python3.6/site-packages/elliottlib/cli/find_builds_cli.py", line 109, in find_builds_cli
    unshipped_nvrps = _fetch_builds_by_kind_rpm(tag_pv_map)
  File "/home/jenkins/.local/lib/python3.6/site-packages/elliottlib/cli/find_builds_cli.py", line 212, in _fetch_builds_by_kind_rpm
    candidates = elliottlib.brew.find_unshipped_build_candidates(base_tag)
  File "/home/jenkins/.local/lib/python3.6/site-packages/elliottlib/brew.py", line 136, in find_unshipped_build_candidates
    candidate_builds = brew_session.listTagged(tag='{}-candidate'.format(base_tag), latest=True, type=kind)
  File "/home/jenkins/.local/lib/python3.6/site-packages/koji/__init__.py", line 2187, in __call__
    return self.__func(self.__name, args, opts)
  File "/home/jenkins/.local/lib/python3.6/site-packages/koji/__init__.py", line 2702, in _callMethod
    raise err
koji.GenericError: Invalid tagInfo: 'rhaos-3.11-rhel-8-candidate'
```