### PR TITLE
Pin rhsl-ruby-2.5 to previous version

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -10,7 +10,7 @@ rhel-8-golang:
 elasticsearch:
   image: openshift/ose-base:elasticsearch
 ruby-25:
-  image: rhscl/ruby-25-rhel7
+  image: rhscl/ruby-25-rhel7:2.5-57 # XXX: Unpleasant pin
 nodejs-6:
   image: openshift/ose-base:rhscl.nodejs.6.rhel7
 nodejs-10:


### PR DESCRIPTION
`logging-fluentd` had this issue:
```
Error: Package: glibc-2.17-292.el7.i686 (rhel-server-rpms-x86_64)
 Requires: glibc-common = 2.17-292.el7
 Installed: glibc-common-2.17-307.el7.1.x86_64 (@anaconda/7.8)
```
Current `:latest` of `rhscl-ruby-25-rhel7` includes a pre-release glibc,
which causes this. This patch is intended to be temporary.