### PR TITLE
Use FDP nightlies, not FDN.

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -98,9 +98,9 @@ repos:
   rhel-fast-datapath-beta-rpms:
     conf:
       baseurl:
-        s390x: http://download-node-02.eng.bos.redhat.com/rhel-7/nightly/FDN/latest-FDP-7-RHEL-7/compose/Server/s390x/os/
-        ppc64le: http://download-node-02.eng.bos.redhat.com/rhel-7/nightly/FDN/latest-FDP-7-RHEL-7/compose/Server/ppc64le/os/
-        x86_64: http://download-node-02.eng.bos.redhat.com/rhel-7/nightly/FDN/latest-FDP-7-RHEL-7/compose/Server/x86_64/os/
+        s390x: http://download-node-02.eng.bos.redhat.com/rhel-7/nightly/FDP/latest-FDP-7-RHEL-7/compose/Server/s390x/os/
+        ppc64le: http://download-node-02.eng.bos.redhat.com/rhel-7/nightly/FDP/latest-FDP-7-RHEL-7/compose/Server/ppc64le/os/
+        x86_64: http://download-node-02.eng.bos.redhat.com/rhel-7/nightly/FDP/latest-FDP-7-RHEL-7/compose/Server/x86_64/os/
     content_set:
       default: rhel-7-fast-datapath-beta-rpms
       optional: true


### PR DESCRIPTION
FDN builds are for internal development only, and must not be used in
potentially shipping products.  FDP nightly composes reflect what has or
will soon be shipped.

CC: @dcbw 