### PR TITLE
ovn-kubernetes: enable fast-datapath-beta repos for OVS/OVN 2.13

### DIFF
--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -12,6 +12,7 @@ content:
 enabled_repos:
 - rhel-server-rpms
 - rhel-server-optional-rpms
+- rhel-fast-datapath-beta-rpms
 - rhel-fast-datapath-rpms
 - rhel-server-extras-rpms
 - rhel-server-ose-rpms


### PR DESCRIPTION
Fixes: https://github.com/openshift/ocp-build-data/pull/412

@wking @knobunc 