### PR TITLE
Update scheduler/descheduler owners to include aos-workloads

### DIFF
--- a/images/atomic-openshift-descheduler.yml
+++ b/images/atomic-openshift-descheduler.yml
@@ -26,3 +26,4 @@ labels:
 name: openshift/ose-descheduler
 owners:
 - rgudimet@redhat.com
+- aos-workloads@redhat.com

--- a/images/ose-cluster-kube-scheduler-operator.yml
+++ b/images/ose-cluster-kube-scheduler-operator.yml
@@ -19,3 +19,4 @@ from:
 name: openshift/ose-cluster-kube-scheduler-operator
 owners:
 - aos-pod@redhat.com
+- aos-workloads@redhat.com


### PR DESCRIPTION
The workloads team are the current owners of the scheduler and descheduler, going forward