### PR TITLE
Pull images with SSL

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -44,7 +44,7 @@ urls:
   cgit: http://pkgs.devel.redhat.com/cgit
 # Is the `brew_image_host` source a secure endpoint or will
 # --insecure=true be required?
-insecure_source: true
+# insecure_source: false
 dist_git_ignore:
   - gating.yaml
 non_release:


### PR DESCRIPTION
With the move to registry-proxy, there should be no need to pull images
insecurely.