### PR TITLE
Remove reg-aws from push list

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -64,9 +64,9 @@ non_release:
   - atomic-openshift-metrics-server-container
   - atomic-openshift-cluster-autoscaler-container
 
-push:
-  registries:
-  - registry.reg-aws.openshift.com:443
+# push:
+#   registries:
+#   - registry.reg-aws.openshift.com:443
 
 sources:
   ose:


### PR DESCRIPTION
The conclusion from [this conversation](http://post-office.corp.redhat.com/archives/aos-team-art/2020-March/msg00041.html) is that the additional push of images to reg-aws is not consumed for 4.y releases. Removing, to save some waiting time.