### PR TITLE
Bump to ansible-2.9

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -83,6 +83,18 @@ public_upstreams:
   "https://github.com/openshift/ose" : "https://github.com/openshift/origin"
 
 repos:
+  rhel-7-server-ansible-2.9-rpms:
+    conf:
+      baseurl:
+        ppc64le: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/power-le/7/7Server/ppc64le/ansible/2.9/os/
+        s390x: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/system-z/7/7Server/s390x/ansible/2.9/os/
+        x86_64: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/ansible/2.9/os/
+    content_set:
+      default: rhel-7-server-ansible-2.9-rpms
+      ppc64le: rhel-7-server-ansible-2.9-for-power-le-rpms
+      s390x: rhel-7-server-ansible-2.9-for-system-z-rpms
+    reposync:
+      enabled: false
   rhel-7-server-ansible-2.8-rpms:
     conf:
       baseurl:

--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -4,6 +4,7 @@ container_yaml:
     - module: github.com/operator-framework/operator-sdk
 content:
   source:
+    dockerfile: release/ansible/Dockerfile
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
@@ -13,7 +14,7 @@ enabled_repos:
 - rhel-server-optional-rpms
 - rhel-server-ose-rpms
 - rhel-server-extras-rpms
-- rhel-7-server-ansible-2.8-rpms
+- rhel-7-server-ansible-2.9-rpms
 from:
   builder:
   - stream: golang

--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -4,7 +4,6 @@ container_yaml:
     - module: github.com/operator-framework/operator-sdk
 content:
   source:
-    dockerfile: release/ansible/Dockerfile
     git:
       branch:
         target: release-{MAJOR}.{MINOR}


### PR DESCRIPTION
Per QE and https://github.com/openshift/openshift-ansible/commit/02c6b7bedacde486669fbeae2ab1cd0bd1c06162, 4.4 openshift-ansible uses ansible 2.9.
I cherry-picked 1cf1054cf8f5a3d3c1021fbb97189c993a21d980 from 4.5 but not sure if bumping the ansible version for ose-ansible-opeator is required or we only need to have entry in group.yml for QE's TPS testing.