### PR TITLE
ovn-kubernetes: disable FDP beta/next repo for release

### DIFF
--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -12,7 +12,6 @@ content:
 enabled_repos:
 - rhel-server-rpms
 - rhel-server-optional-rpms
-- rhel-fast-datapath-beta-rpms
 - rhel-fast-datapath-rpms
 - rhel-server-extras-rpms
 - rhel-server-ose-rpms


### PR DESCRIPTION
What's in FDP itself is good enough for ovnkube and is part of
the FDP 20.C.1 release (and thus errata-ed).

@danwinship @sosiouxme 