### PR TITLE
Re-enable image-inspector

### DIFF
--- a/images/image-inspector.yml
+++ b/images/image-inspector.yml
@@ -1,7 +1,3 @@
-# <lmeyer> I don't believe anything needs this to be built and released
-# regularly. this is used by cloudforms and the version should correspond to
-# the RPM it installs.  so, let's not re-version and build it.
-mode: disabled
 enabled_repos:
 - rhel-server-ose-rpms
 from:


### PR DESCRIPTION
Ship `image-inspector` with our next 3.11 release. **if** that's what we agree on this thread: https://coreos.slack.com/archives/CB95J6R4N/p1588169544270000