### PR TITLE
Add aos-workloads to descheduler owners

### DIFF
--- a/images/atomic-openshift-descheduler.yml
+++ b/images/atomic-openshift-descheduler.yml
@@ -26,3 +26,4 @@ labels:
 name: openshift/ose-descheduler
 owners:
 - rgudimet@redhat.com
+- aos-workloads@redhat.com


### PR DESCRIPTION
This adds aos-workloads to the list of descheduler owners

Is there anything we need to do to ensure this is copied forward for future versions? I added it in 4.5 as well, aos-workloads should be on the list for each release going forward.