### PR TITLE
Add ose-leader-elector to non_release

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -59,6 +59,7 @@ non_release:
   - snapshot-controller
   - snapshot-provisioner
   - openshift-enterprise-service-idler
+  - ose-leader-elector
   rpms:
   - atomic-openshift-service-idler
   - atomic-openshift-metrics-server-container


### PR DESCRIPTION
This image is related to a feature of kuryr-kubernetes that is not
enabled at all on 4.5, so we should be able to skip releasing it.