### PR TITLE
Updating logging image owners to be team-logging@redhat.com

### DIFF
--- a/images/cluster-logging-operator.yml
+++ b/images/cluster-logging-operator.yml
@@ -23,9 +23,7 @@ labels:
   io.openshift.tags: openshift,logging
 name: openshift/ose-cluster-logging-operator
 owners:
-- jcantril@redhat.com
-- ewolinet@redhat.com
-- aos-logging@redhat.com
+- team-logging@redhat.com
 update-csv:
   manifests-dir: manifests/
   bundle-dir: "{MAJOR}.{MINOR}/"

--- a/images/elasticsearch-operator.yml
+++ b/images/elasticsearch-operator.yml
@@ -17,9 +17,7 @@ from:
   member: openshift-enterprise-base
 name: openshift/ose-elasticsearch-operator
 owners:
-- jcantril@redhat.com
-- ewolinet@redhat.com
-- aos-logging@redhat.com
+- team-logging@redhat.com
 update-csv:
   manifests-dir: manifests/
   bundle-dir: "{MAJOR}.{MINOR}/"

--- a/images/elasticsearch-proxy.yml
+++ b/images/elasticsearch-proxy.yml
@@ -24,4 +24,4 @@ name: openshift/ose-elasticsearch-proxy
 dependents:
 - elasticsearch-operator
 owners:
-- aos-logging@redhat.com
+- team-logging@redhat.com

--- a/images/logging-curator5.yml
+++ b/images/logging-curator5.yml
@@ -23,8 +23,7 @@ labels:
   vendor: Red Hat
 name: openshift/ose-logging-curator5
 owners:
-- jcantril@redhat.com
-- ewolinet@redhat.com
+- team-logging@redhat.com
 push:
   repos:
   - openshift/logging-curator5

--- a/images/logging-elasticsearch6.yml
+++ b/images/logging-elasticsearch6.yml
@@ -23,8 +23,7 @@ labels:
   vendor: Red Hat
 name: openshift/ose-logging-elasticsearch6
 owners:
-- jcantril@redhat.com
-- ewolinet@redhat.com
+- team-logging@redhat.com
 push:
   repos:
   - openshift/logging-elasticsearch6

--- a/images/logging-eventrouter.yml
+++ b/images/logging-eventrouter.yml
@@ -18,4 +18,4 @@ push:
   - openshift/logging-eventrouter
   - openshift/ose-logging-eventrouter
 owners:
-- aos-logging@redhat.com
+- team-logging@redhat.com

--- a/images/logging-fluentd.yml
+++ b/images/logging-fluentd.yml
@@ -23,8 +23,7 @@ labels:
   vendor: Red Hat
 name: openshift/ose-logging-fluentd
 owners:
-- jcantril@redhat.com
-- ewolinet@redhat.com
+- team-logging@redhat.com
 push:
   repos:
   - openshift/logging-fluentd

--- a/images/logging-kibana6.yml
+++ b/images/logging-kibana6.yml
@@ -22,8 +22,7 @@ labels:
   vendor: Red Hat
 name: openshift/ose-logging-kibana6
 owners:
-- jcantril@redhat.com
-- ewolinet@redhat.com
+- team-logging@redhat.com
 push:
   repos:
   - openshift/logging-kibana6


### PR DESCRIPTION
the email group aos-logging is too large and contains members other than the logging team itself

cc @jcantrill 