### PR TITLE
ovn-kubernetes: disable fast-datapath-beta repos now that SCR is active

### DIFF
--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -12,7 +12,6 @@ content:
 enabled_repos:
 - rhel-server-rpms
 - rhel-server-optional-rpms
-- rhel-fast-datapath-beta-rpms
 - rhel-fast-datapath-rpms
 - rhel-server-extras-rpms
 - rhel-server-ose-rpms


### PR DESCRIPTION
Now that we can cross-tag between FDP and RHAOS tags, no need for the
beta repo in non-development OpenShift branches.

@jupierce 