### PR TITLE
[openshift-4.6] remove fast-datapath-beta repos now that SCR is active

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -104,17 +104,6 @@ repos:
       s390x: rhel-7-server-ansible-2.8-for-system-z-rpms
     reposync:
       enabled: false
-  rhel-fast-datapath-beta-rpms:
-    conf:
-      baseurl:
-        ppc64le: http://download-node-02.eng.bos.redhat.com/rhel-7/nightly/FDP/latest-FDP-7-RHEL-7/compose/Server/ppc64le/os/
-        s390x: http://download-node-02.eng.bos.redhat.com/rhel-7/nightly/FDP/latest-FDP-7-RHEL-7/compose/Server/s390x/os/
-        x86_64: http://download-node-02.eng.bos.redhat.com/rhel-7/nightly/FDP/latest-FDP-7-RHEL-7/compose/Server/x86_64/os/
-    content_set:
-      default: rhel-7-fast-datapath-beta-rpms
-      optional: true
-      ppc64le: rhel-7-for-power-le-fast-datapath-beta-rpms
-      s390x: rhel-7-for-system-z-fast-datapath-beta-rpms
   rhel-fast-datapath-rpms:
     conf:
       baseurl:

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -12,7 +12,6 @@ content:
 enabled_repos:
 - rhel-server-rpms
 - rhel-server-optional-rpms
-- rhel-fast-datapath-beta-rpms
 - rhel-fast-datapath-rpms
 - rhel-server-extras-rpms
 - rhel-server-ose-rpms


### PR DESCRIPTION
If we need development RPMs in 4.6 we'll just tag the right ones in.

@jupierce 