### PR TITLE
[logging] Migrate using ubi7 base images

### DIFF
--- a/images/logging-curator5.yml
+++ b/images/logging-curator5.yml
@@ -14,7 +14,7 @@ enabled_repos:
 - rhel-server-ose-rpms
 - rhel-server-extras-rpms
 from:
-  stream: rhel
+  stream: python-36
 labels:
   License: GPLv2+
   io.k8s.description: Curator elasticsearch container for elasticsearch deletion/archival

--- a/images/logging-fluentd.yml
+++ b/images/logging-fluentd.yml
@@ -12,9 +12,7 @@ enabled_repos:
 - rhel-server-ose-rpms
 - rhel-server-rhscl-rpms
 from:
-  builder:
-  - stream: ruby-25
-  stream: rhel
+  stream: ruby-25
 labels:
   License: GPLv2+
   io.k8s.description: Fluentd container for collecting of container logs

--- a/streams.yml
+++ b/streams.yml
@@ -11,6 +11,8 @@ elasticsearch:
   image: openshift/ose-base:elasticsearch
 ruby-25:
   image: rhscl/ruby-25-rhel7
+python-36:
+  image: rhscl/python-36-rhel7
 nodejs-6:
   image: openshift/ose-base:rhscl.nodejs.6.rhel7
 nodejs-10:


### PR DESCRIPTION
This PR addresses upcoming changes in base images used to build the logging stack.

**Depends on:** openshift/origin-aggregated-logging#1892