### PR TITLE
Switch to build hyperkube image and rpm to openshift/kubernetes

### DIFF
--- a/images/openshift-enterprise-hyperkube.yml
+++ b/images/openshift-enterprise-hyperkube.yml
@@ -1,11 +1,14 @@
 container_yaml:
   go:
     modules:
-    - module: github.com/openshift/origin
+    - module: k8s.io/kubernetes
 content:
   source:
-    alias: ose
-    dockerfile: images/hyperkube/Dockerfile.rhel
+    dockerfile: openshift-hack/images/hyperkube/Dockerfile.rhel
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/kubernetes.git
 distgit:
   namespace: containers
 enabled_repos:

--- a/rpms/openshift.yml
+++ b/rpms/openshift.yml
@@ -1,7 +1,10 @@
 content:
   source:
-    alias: ose
-    specfile: origin.spec
+    specfile: openshift.spec
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/kubernetes.git
   build:
     use_source_tito_config: false
     tito_target: aos-{MAJOR}.{MINOR}


### PR DESCRIPTION
As of 4.6 the hyperkube builds are moving from openshift/origin to openshift/kubernetes to simplify the maintenance of our fork of kubernetes.

My intent with this PR is to determine the necessary ART configuration in preparation for an orchestrated transition. I'm marking as WIP until both the configuration and transition plan have been finalized.