### PR TITLE
images: add rhel-server-ose-rpms for prom-label-proxy

### DIFF
--- a/images/prom-label-proxy.yml
+++ b/images/prom-label-proxy.yml
@@ -12,6 +12,7 @@ content:
 enabled_repos:
 - rhel-server-rpms
 - rhel-server-optional-rpms
+- rhel-server-ose-rpms
 from:
   builder:
   - stream: golang


### PR DESCRIPTION
To build prom-label-proxy we need the `prometheus-promu` package which is available from rhel-server-ose-rpms if I'm not mistaken.

For example, this is the list of repositories for Prometheus:
https://github.com/openshift/ocp-build-data/blob/9e8c4b4e8c300b72356cbe6f04f7315c70877ab3/images/golang-github-prometheus-prometheus.yml#L12-L15