### PR TITLE
Make ose-clusterresourceoverride-rhel7-operator GA

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -53,8 +53,6 @@ dist_git_ignore:
   - gating.yaml
 non_release:
   images:
-  - clusterresourceoverride
-  - clusterresourceoverride-operator
   - openshift-enterprise-base
   - ose-haproxy-router-base
   - openshift-enterprise-service-idler


### PR DESCRIPTION
Per https://coreos.slack.com/archives/CJARLA942/p1593765423362300,
remove the operator from non_release on behalf of QE's request.