### PR TITLE
Install devel packages found in rhel7 builder + add aarch64

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -4,6 +4,7 @@ arches:
 - x86_64
 - ppc64le
 - s390x
+- aarch64
 
 vars:
   MAJOR: 4
@@ -26,13 +27,15 @@ repos:
       extra_options:
         module_hotfixes: 1
       baseurl:
+        aarch64: http://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/aarch64/
         ppc64le: http://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/ppc64le/
         s390x: http://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/s390x/
         x86_64: http://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-{MAJOR}.{MINOR}-rhel-8-build/latest/x86_64/
 
     # These content sets are not used, so just putting something here
     content_set:
-      default: rhel-7-server-ose-{MAJOR}.{MINOR}-rpms
-      ppc64le: rhel-7-for-power-le-ose-{MAJOR}.{MINOR}-rpms
-      s390x: rhel-7-for-system-z-ose-{MAJOR}.{MINOR}-rpms
+      default: rhocp-{MAJOR}.{MINOR}-for-rhel-8-x86_64-rpms
+      aarch64: rhocp-{MAJOR}.{MINOR}-for-rhel-8-aarch64-rpms
+      ppc64le: rhocp-{MAJOR}.{MINOR}-for-rhel-8-ppc64le-rpms
+      s390x: rhocp-{MAJOR}.{MINOR}-for-rhel-8-s390x-rpms
       optional: true

--- a/images/openshift-golang-builder.Dockerfile
+++ b/images/openshift-golang-builder.Dockerfile
@@ -10,5 +10,7 @@ LABEL summary="$SUMMARY" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
       version="$VERSION"
 
-RUN yum install -y --setopt=tsflags=nodocs "go-toolset-$VERSION.*" && \
+RUN yum install -y --setopt=tsflags=nodocs \
+    bc file findutils gpgme git hostname lsof make socat tar tree util-linux wget which zip \
+    "go-toolset-$VERSION.*" goversioninfo openssl openssl-devel systemd-devel gpgme-devel libassuan-devel && \
     yum clean all -y


### PR DESCRIPTION
Until now, the rhel8 golang-builder was only used for a handful of images.  This should help facilitate switching the rest.

A successful scratch build was made internally.