### PR TITLE
rhel-8-golang-1.14: Make functionally equivalent to RHEL7 golang-builder

### DIFF
--- a/images/openshift-golang-builder.Dockerfile
+++ b/images/openshift-golang-builder.Dockerfile
@@ -1,6 +1,9 @@
 FROM openshift/ose-base:ubi8
 
 ENV SUMMARY="RHEL8 based Go builder image for OpenShift ART" \
+    container=oci \
+    GOFLAGS='-mod=vendor' \
+    GOPATH=/go \
     VERSION="1.14"
 
 LABEL summary="$SUMMARY" \
@@ -13,4 +16,5 @@ LABEL summary="$SUMMARY" \
 RUN yum install -y --setopt=tsflags=nodocs \
     bc file findutils gpgme git hostname lsof make socat tar tree util-linux wget which zip \
     "go-toolset-$VERSION.*" goversioninfo openssl openssl-devel systemd-devel gpgme-devel libassuan-devel && \
+    mkdir -p /go/src && \
     yum clean all -y


### PR DESCRIPTION
However, the MANPATH, X_SCLS, LD_LIBRARY_PATH, PATH, and PKG_CONFIG_PATH
variables need not be set, as RHEL8 golang is a module rather than an SCL.