### PR TITLE
Add build stage on cluster-node-tuning-operator

### DIFF
--- a/images/cluster-node-tuning-operator.yml
+++ b/images/cluster-node-tuning-operator.yml
@@ -15,6 +15,7 @@ enabled_repos:
 from:
   builder:
   - stream: golang
+  - stream: rhel
   member: openshift-enterprise-base
 name: openshift/ose-cluster-node-tuning-operator
 owners:


### PR DESCRIPTION
Adding one more stage to `cluster-node-tuning-operator`'s Dockerfile, to reflect its current upstream counterpart: https://github.com/jmencak/cluster-node-tuning-operator/blob/9fff20cec49b986add48f92059113520cc3d467a/Dockerfile