### PR TITLE
Add kuryr-kubernetes to 4.2 non_release images

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -55,6 +55,8 @@ non_release:
   - openshift-enterprise-autoheal
   - csi-provisioner
   - efs-provisioner
+  - kuryr-cni
+  - kuryr-controller
   - ose-haproxy-router-base
   - ose-manila-provisioner
   - snapshot-controller


### PR DESCRIPTION
We ended up including those images in 4.2, but they were never supported
due to PM decisions. This commit removes them from there.