### PR TITLE
4.5: Correct rhel-8-server-ose content_set

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -169,10 +169,10 @@ repos:
         s390x: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el8/building/s390x/os
         x86_64: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el8/building/x86_64/os
     content_set:
-      default: rhel-8-server-ose-{MAJOR}.{MINOR}-rpms
+      default: rhocp-{MAJOR}.{MINOR}-for-rhel-8-x86_64-rpms
       optional: true
-      ppc64le: rhel-8-for-power-le-ose-{MAJOR}.{MINOR}-rpms
-      s390x: rhel-8-for-system-z-ose-{MAJOR}.{MINOR}-rpms
+      ppc64le: rhocp-{MAJOR}.{MINOR}-for-rhel-8-ppc64le-rpms
+      s390x: rhocp-{MAJOR}.{MINOR}-for-rhel-8-s390x-rpms
   rhel-server-rhscl-rpms:
     conf:
       baseurl:


### PR DESCRIPTION
The ose content sets for rhel-8 do not match the naming scheme for
rhel-7. This results in a content_sets.yml that differs from the
configured repositories.

To test:

```sh
curl -sSL -XPOST --header "Accept-Encoding: gzip, deflate" --header "Accept: */*" --header "Content-Type: application/json" --header "Authorization: Basic ABC" -d '
{
  "criteria": {
    "fields": [
      "id",
      "notes"
    ],
    "filters": {
      "notes.arch": {
        "$in": [
          "x86_64", "s390x", "ppc64le"
        ]
      },
      "notes.content_set": {
        "$in": [
          "rhocp-4.6-for-rhel-8-x86_64-rpms",
          "rhocp-4.6-for-rhel-8-ppc64le-rpms",
          "rhocp-4.6-for-rhel-8-s390x-rpms"
        ]
      }
    }
  }
}

' "https://pulp.dist.prod.ext.phx2.redhat.com/pulp/api/v2/repositories/search/" | jq -r '.[] | .id + " " + .notes.content_set'
rhocp-4_DOT_6-for-rhel-8-ppc64le-rpms rhocp-4.6-for-rhel-8-ppc64le-rpms
rhocp-4_DOT_6-for-rhel-8-s390x-rpms rhocp-4.6-for-rhel-8-s390x-rpms
rhocp-4_DOT_6-for-rhel-8-x86_64-rpms rhocp-4.6-for-rhel-8-x86_64-rpms
```