### PR TITLE
4.5 builder images

### DIFF
--- a/images/golang-github-prometheus-alertmanager.yml
+++ b/images/golang-github-prometheus-alertmanager.yml
@@ -11,6 +11,7 @@ content:
       url: git@github.com:openshift-priv/prometheus-alertmanager.git
 enabled_repos:
 - rhel-server-rpms
+- rhel-server-ose-rpms # Needed for builder
 from:
   builder:
   - stream: golang

--- a/images/golang-github-prometheus-node_exporter.yml
+++ b/images/golang-github-prometheus-node_exporter.yml
@@ -11,6 +11,7 @@ content:
       url: git@github.com:openshift-priv/node_exporter.git
 enabled_repos:
 - rhel-server-rpms
+- rhel-server-ose-rpms # Needed for builder
 from:
   builder:
   - stream: golang

--- a/images/golang-github-prometheus-prometheus.yml
+++ b/images/golang-github-prometheus-prometheus.yml
@@ -11,6 +11,7 @@ content:
       url: git@github.com:openshift-priv/prometheus.git
 enabled_repos:
 - rhel-server-rpms
+- rhel-server-ose-rpms # Needed for builder
 from:
   builder:
   - stream: golang

--- a/images/ironic-ipa-downloader.yml
+++ b/images/ironic-ipa-downloader.yml
@@ -14,6 +14,7 @@ enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
 - rhel-8-server-ose-rpms
+- openstack-16-for-rhel-8-rpms # Needed for builder
 from:
   builder:
   - stream: rhel8

--- a/images/openshift-enterprise-service-catalog.yml
+++ b/images/openshift-enterprise-service-catalog.yml
@@ -11,6 +11,7 @@ content:
     path: images/service-catalog
 enabled_repos:
 - rhel-server-rpms
+- rhel-server-ose-rpms # Needed for builder
 from:
   member: openshift-enterprise-base
 labels:

--- a/images/openshift-enterprise-service-idler.yml
+++ b/images/openshift-enterprise-service-idler.yml
@@ -13,6 +13,7 @@ content:
     path: images/service-idler
 enabled_repos:
 - rhel-server-rpms
+- rhel-server-ose-rpms # Needed for builder
 from:
   member: openshift-enterprise-base
 labels:

--- a/images/operator-registry.yml
+++ b/images/operator-registry.yml
@@ -10,6 +10,7 @@ content:
       url: git@github.com:operator-framework/operator-registry.git
 enabled_repos:
 - rhel-server-rpms
+- rhel-server-optional-rpms # Needed for builder
 from:
   builder:
   - stream: golang

--- a/images/thanos.yml
+++ b/images/thanos.yml
@@ -13,6 +13,7 @@ distgit:
   component: ose-thanos-container
 enabled_repos:
 - rhel-server-rpms
+- rhel-server-ose-rpms # Needed for builder
 from:
   builder:
   - stream: golang


### PR DESCRIPTION
This reenables repositories that are needed in multistage image builds. It assumes https://github.com/openshift/doozer/pull/244 is *not* merged.