### PR TITLE
Install diffutils and rsync

### DIFF
--- a/images/openshift-golang-builder.Dockerfile
+++ b/images/openshift-golang-builder.Dockerfile
@@ -14,7 +14,7 @@ LABEL summary="$SUMMARY" \
       version="$VERSION"
 
 RUN yum install -y --setopt=tsflags=nodocs \
-    bc file findutils gpgme git hostname lsof make socat tar tree util-linux wget which zip \
+    bc diffutils file findutils gpgme git hostname lsof make rsync socat tar tree util-linux wget which zip \
     "go-toolset-$VERSION.*" goversioninfo openssl openssl-devel systemd-devel gpgme-devel libassuan-devel && \
     mkdir -p /go/src && \
     yum clean all -y


### PR DESCRIPTION
These are needed for building ose-hyperkube, but just happened to be
pulled into the rhel7 golang-builder as dependencies of other packages.