### PR TITLE
The reference CNI plugins should have an additional layer for windows binaries

### DIFF
--- a/images/ose-containernetworking-plugins.yml
+++ b/images/ose-containernetworking-plugins.yml
@@ -15,6 +15,7 @@ from:
   builder:
   - stream: rhel-8-golang
   - stream: golang
+  - stream: rhel-8-golang
   member: openshift-enterprise-base
 name: openshift/ose-container-networking-plugins
 owners:


### PR DESCRIPTION
This adds another layer reference, to resolve a dockerfile that has failed to reconcile.

Dockerfile in question changed in this PR @ https://github.com/openshift/containernetworking-plugins/pull/30