### PR TITLE
Add rhel-server-ose-rpms back to ose-prometheus-node-exporter image

### DIFF
--- a/images/golang-github-prometheus-node_exporter.yml
+++ b/images/golang-github-prometheus-node_exporter.yml
@@ -11,6 +11,7 @@ content:
       url: git@github.com:openshift-priv/node_exporter.git
 enabled_repos:
 - rhel-server-rpms
+- rhel-server-ose-rpms  # required by the builder
 from:
   builder:
   - stream: golang


### PR DESCRIPTION
The builder installs packages from rhel-server-ose-rpms, but that package will not be in the resulting image.