### PR TITLE
images: add ose-rpms to fix broken build with missing promu package

### DIFF
--- a/images/golang-github-prometheus-alertmanager.yml
+++ b/images/golang-github-prometheus-alertmanager.yml
@@ -11,6 +11,9 @@ content:
       url: git@github.com:openshift-priv/prometheus-alertmanager.git
 enabled_repos:
 - rhel-server-rpms
+- rhel-server-ose-rpms  # required by the builder
+non_shipping_repos:
+- rhel-server-ose-rpms
 from:
   builder:
   - stream: golang

--- a/images/golang-github-prometheus-prometheus.yml
+++ b/images/golang-github-prometheus-prometheus.yml
@@ -11,6 +11,9 @@ content:
       url: git@github.com:openshift-priv/prometheus.git
 enabled_repos:
 - rhel-server-rpms
+- rhel-server-ose-rpms  # required by the builder
+non_shipping_repos:
+- rhel-server-ose-rpms
 from:
   builder:
   - stream: golang

--- a/images/prom-label-proxy.yml
+++ b/images/prom-label-proxy.yml
@@ -11,6 +11,9 @@ content:
       url: git@github.com:openshift-priv/prom-label-proxy.git
 enabled_repos:
 - rhel-server-rpms
+- rhel-server-ose-rpms  # required by the builder
+non_shipping_repos:
+- rhel-server-ose-rpms
 from:
   builder:
   - stream: golang

--- a/images/thanos.yml
+++ b/images/thanos.yml
@@ -13,6 +13,9 @@ distgit:
   component: ose-thanos-container
 enabled_repos:
 - rhel-server-rpms
+- rhel-server-ose-rpms  # required by the builder
+non_shipping_repos:
+- rhel-server-ose-rpms
 from:
   builder:
   - stream: golang


### PR DESCRIPTION
node_exporter has been fixed already in https://github.com/openshift/ocp-build-data/pull/580 and https://github.com/openshift/ocp-build-data/pull/579.
/cc @vfreex @openshift/openshift-team-monitoring 