### PR TITLE
[cluster-logging-operator] Add missing member to oc cli image

### DIFF
--- a/images/cluster-logging-operator.yml
+++ b/images/cluster-logging-operator.yml
@@ -13,6 +13,7 @@ enabled_repos:
 from:
   builder:
   - stream: golang
+  - member: openshift-enterprise-cli
   member: openshift-enterprise-base
 labels:
   License: GPLv2+


### PR DESCRIPTION
This PR addresses a latest build breaking change in cluster logging operator introduced by openshift/cluster-logging-operator#628. In detail the referenced PR adds a new `FROM` directive to include the `oc` utility in its build.

/cc @sosiouxme @thiagoalessio 