### PR TITLE
Correct rhel-8 fast datapath content sets

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -232,9 +232,9 @@ repos:
         # ppc64le: http://download.lab.bos.redhat.com/rcm-guest/puddles/Multi-Arch/Fast-DataPath/EL8-Production/latest/ppc64le/os/
         # s390x: http://download.lab.bos.redhat.com/rcm-guest/puddles/Multi-Arch/Fast-DataPath/EL8-Production/latest/s390x/os/
     content_set:
-      default: rhel-8-for-x86_64-fast-datapath-rpms
-      ppc64le: rhel-8-for-ppc64le-fast-datapath-rpms
-      s390x: rhel-8-for-s390x-fast-datapath-rpms
+      default: fast-datapath-for-rhel-8-x86_64-rpms
+      ppc64le: fast-datapath-for-rhel-8-ppc64le-rpms
+      s390x: fast-datapath-for-rhel-8-s390x-rpms
       optional: true
     reposync:
       enabled: false


### PR DESCRIPTION
Conten sets were ignored. These are the correct names:

```
curl -sSL -XPOST --header "Accept-Encoding: gzip, deflate" --header "Accept: */*" --header "Content-Type: application/json" --header "Authorization: Basic abc" -d '
{
  "criteria": {
    "fields": [
      "id",
      "notes"
    ],
    "filters": {
      "notes.arch": {
        "$in": [
          "x86_64", "s390x", "ppc64le"
        ]
      },
      "notes.content_set": {
        "$in": [
          "fast-datapath-for-rhel-8-x86_64-rpms",
          "fast-datapath-for-rhel-8-ppc64le-rpms",
          "fast-datapath-for-rhel-8-s390x-rpms"
        ]
      }
    }
  }
}

' "https://pulp.dist.prod.ext.phx2.redhat.com/pulp/api/v2/repositories/search/" | jq
```