### PR TITLE
ART-2082: Only reposync unembargoed plashets

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -145,7 +145,7 @@ repos:
       s390x: rhel-7-for-system-z-optional-rpms
     reposync:
       enabled: false
-  rhel-server-ose-rpms:
+  rhel-server-ose-rpms-embargoed:
     conf:
       baseurl:
         ppc64le: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}/building-embargoed/ppc64le/os
@@ -156,8 +156,18 @@ repos:
       optional: true
       ppc64le: rhel-7-for-power-le-ose-{MAJOR}.{MINOR}-rpms
       s390x: rhel-7-for-system-z-ose-{MAJOR}.{MINOR}-rpms
+    reposync:
+      enabled: false
+  rhel-server-ose-rpms:  # for reposync and CI build only
+    conf:
+      baseurl:
+        ppc64le: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}/building/ppc64le/os
+        s390x: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}/building/s390x/os
+        x86_64: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}/building/x86_64/os
+    content_set:  # keep empty to avoid being used in ART build or confusing elliott redundant content_set check
+      optional: true
   # Included to trigger reposync of rhel-8 rpms
-  rhel-8-server-ose-rpms:
+  rhel-8-server-ose-rpms-embargoed:
     conf:
       baseurl:
         ppc64le: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el8/building-embargoed/ppc64le/os
@@ -168,6 +178,16 @@ repos:
       optional: true
       ppc64le: rhocp-{MAJOR}.{MINOR}-for-rhel-8-ppc64le-rpms
       s390x: rhocp-{MAJOR}.{MINOR}-for-rhel-8-s390x-rpms
+    reposync:
+      enabled: false
+  rhel-8-server-ose-rpms:  # for reposync and CI build only
+    conf:
+      baseurl:
+        ppc64le: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el8/building/ppc64le/os
+        s390x: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el8/building/s390x/os
+        x86_64: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el8/building/x86_64/os
+    content_set:  # keep empty to avoid being used in ART build or confusing elliott redundant content_set check
+      optional: true
   rhel-server-rhscl-rpms:
     conf:
       baseurl:

--- a/images/atomic-openshift-node-problem-detector.yml
+++ b/images/atomic-openshift-node-problem-detector.yml
@@ -12,7 +12,7 @@ content:
 enabled_repos:
 - rhel-server-rpms
 - rhel-server-optional-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 from:
   builder:
   - stream: golang

--- a/images/csi-driver-nfs.yml
+++ b/images/csi-driver-nfs.yml
@@ -12,7 +12,7 @@ content:
 enabled_repos:
 - rhel-server-rpms
 - rhel-server-optional-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 from:
   builder:
   - stream: golang

--- a/images/golang-github-prometheus-alertmanager.yml
+++ b/images/golang-github-prometheus-alertmanager.yml
@@ -11,9 +11,9 @@ content:
       url: git@github.com:openshift-priv/prometheus-alertmanager.git
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms  # required by the builder
+- rhel-server-ose-rpms-embargoed  # required by the builder
 non_shipping_repos:
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 from:
   builder:
   - stream: golang

--- a/images/golang-github-prometheus-node_exporter.yml
+++ b/images/golang-github-prometheus-node_exporter.yml
@@ -11,9 +11,9 @@ content:
       url: git@github.com:openshift-priv/node_exporter.git
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms  # required by the builder
+- rhel-server-ose-rpms-embargoed  # required by the builder
 non_shipping_repos:
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 from:
   builder:
   - stream: golang

--- a/images/golang-github-prometheus-prometheus.yml
+++ b/images/golang-github-prometheus-prometheus.yml
@@ -11,9 +11,9 @@ content:
       url: git@github.com:openshift-priv/prometheus.git
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms  # required by the builder
+- rhel-server-ose-rpms-embargoed  # required by the builder
 non_shipping_repos:
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 from:
   builder:
   - stream: golang

--- a/images/hadoop.yml
+++ b/images/hadoop.yml
@@ -8,7 +8,7 @@ content:
 enabled_repos:
 - rhel-server-rpms
 - rhel-server-optional-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 from:
   builder:
   - stream: rhel
@@ -22,4 +22,4 @@ arches:
 - x86_64
 non_shipping_repos:
 - rhel-server-optional-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed

--- a/images/ironic-hardware-inventory-recorder-image.yml
+++ b/images/ironic-hardware-inventory-recorder-image.yml
@@ -17,7 +17,7 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 - openstack-16-for-rhel-8-rpms
 from:
   stream: rhel8

--- a/images/ironic-inspector.yml
+++ b/images/ironic-inspector.yml
@@ -13,7 +13,7 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 - openstack-16-for-rhel-8-rpms
 from:
   stream: rhel8

--- a/images/ironic-ipa-downloader.yml
+++ b/images/ironic-ipa-downloader.yml
@@ -13,7 +13,7 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 - openstack-16-for-rhel-8-rpms
 from:
   builder:
@@ -35,4 +35,4 @@ scan_sources:
 owners:
 - ironic-osp-owners@redhat.com
 non_shipping_repos:
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed

--- a/images/ironic-rhcos-downloader.yml
+++ b/images/ironic-rhcos-downloader.yml
@@ -13,7 +13,7 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 - openstack-16-for-rhel-8-rpms
 from:
   stream: rhel8

--- a/images/ironic-static-ip-manager.yml
+++ b/images/ironic-static-ip-manager.yml
@@ -13,11 +13,11 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 from:
   stream: rhel8
 name: openshift/ose-ironic-static-ip-manager
 owners:
 - ironic-osp-owners@redhat.com
 non_shipping_repos:
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed

--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -13,7 +13,7 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 - openstack-16-for-rhel-8-rpms
 from:
   builder:
@@ -23,4 +23,4 @@ name: openshift/ose-ironic
 owners:
 - ironic-osp-owners@redhat.com
 non_shipping_repos:
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed

--- a/images/jenkins-agent-maven-35-rhel7.yml
+++ b/images/jenkins-agent-maven-35-rhel7.yml
@@ -8,7 +8,7 @@ content:
     path: agent-maven-3.5
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-optional-rpms
+- rhel-server-ose-rpms-embargoed
 - rhel-server-rhscl-rpms
 from:
   member: jenkins-slave-base-rhel7

--- a/images/jenkins-agent-nodejs-10-rhel7.yml
+++ b/images/jenkins-agent-nodejs-10-rhel7.yml
@@ -8,7 +8,7 @@ content:
     path: agent-nodejs-10
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 - rhel-server-rhscl-rpms
 from:
   member: jenkins-slave-base-rhel7

--- a/images/jenkins-agent-nodejs-12-rhel7.yml
+++ b/images/jenkins-agent-nodejs-12-rhel7.yml
@@ -8,7 +8,7 @@ content:
     path: agent-nodejs-12
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 - rhel-server-rhscl-rpms
 from:
   member: jenkins-slave-base-rhel7

--- a/images/jenkins-slave-base-rhel7.yml
+++ b/images/jenkins-slave-base-rhel7.yml
@@ -8,7 +8,7 @@ content:
     path: slave-base
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 from:
   builder:
   - stream: golang

--- a/images/kuryr-cni.yml
+++ b/images/kuryr-cni.yml
@@ -14,7 +14,7 @@ enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
 - rhel-8-fast-datapath-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 - openstack-16-for-rhel-8-rpms
 from:
   builder:

--- a/images/kuryr-controller.yml
+++ b/images/kuryr-controller.yml
@@ -14,7 +14,7 @@ enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
 - rhel-8-fast-datapath-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 - openstack-16-for-rhel-8-rpms
 from:
   stream: rhel8

--- a/images/logging-elasticsearch6.yml
+++ b/images/logging-elasticsearch6.yml
@@ -11,7 +11,7 @@ distgit:
 enabled_repos:
 - rhel-server-rpms
 - rhel-server-optional-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 - rhel-server-extras-rpms
 from:
   stream: rhel
@@ -33,4 +33,4 @@ dependents:
 non_shipping_repos:
 - rhel-server-extras-rpms
 - rhel-server-optional-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed

--- a/images/logging-eventrouter.yml
+++ b/images/logging-eventrouter.yml
@@ -1,7 +1,7 @@
 enabled_repos:
 - rhel-server-rpms
 - rhel-server-optional-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 - rhel-server-extras-rpms
 from:
   stream: rhel
@@ -22,4 +22,4 @@ owners:
 non_shipping_repos:
 - rhel-server-extras-rpms
 - rhel-server-optional-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed

--- a/images/logging-kibana6.yml
+++ b/images/logging-kibana6.yml
@@ -11,7 +11,7 @@ distgit:
 enabled_repos:
 - rhel-server-rpms
 - rhel-server-optional-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 from:
   stream: nodejs-10
 labels:
@@ -30,4 +30,4 @@ push:
 dependents:
 - elasticsearch-operator
 non_shipping_repos:
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed

--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -12,7 +12,7 @@ content:
 enabled_repos:
 - rhel-server-rpms
 - rhel-server-optional-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 - rhel-server-extras-rpms
 - rhel-7-server-ansible-2.9-rpms
 from:

--- a/images/openshift-enterprise-egress-dns-proxy.yml
+++ b/images/openshift-enterprise-egress-dns-proxy.yml
@@ -10,7 +10,7 @@ distgit:
   namespace: containers
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 from:
   member: openshift-enterprise-base
 labels:

--- a/images/openshift-enterprise-haproxy-router.yml
+++ b/images/openshift-enterprise-haproxy-router.yml
@@ -7,7 +7,7 @@ content:
       url: git@github.com:openshift-priv/router.git
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 from:
   member: ose-haproxy-router-base
 labels:

--- a/images/openshift-enterprise-service-catalog.yml
+++ b/images/openshift-enterprise-service-catalog.yml
@@ -27,4 +27,4 @@ owners:
 - jlanford@redhat.com
 non_shipping_repos:
 - rhel-server-optional-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed

--- a/images/openshift-enterprise-service-idler.yml
+++ b/images/openshift-enterprise-service-idler.yml
@@ -27,4 +27,4 @@ owners:
 - sross@redhat.com
 non_shipping_repos:
 - rhel-server-optional-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed

--- a/images/openshift-enterprise-tests.yml
+++ b/images/openshift-enterprise-tests.yml
@@ -10,7 +10,7 @@ distgit:
   namespace: containers
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 from:
   builder:
   - stream: golang

--- a/images/openshift-jenkins-2.yml
+++ b/images/openshift-jenkins-2.yml
@@ -12,7 +12,7 @@ content:
       replacement: INSTALL_JENKINS_VIA_RPMS=true
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 from:
   builder:
   - stream: golang

--- a/images/ose-baremetal-installer.yml
+++ b/images/ose-baremetal-installer.yml
@@ -11,7 +11,7 @@ content:
       url: git@github.com:openshift-priv/installer.git
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 from:
   builder:
   - stream: golang

--- a/images/ose-haproxy-router-base.yml
+++ b/images/ose-haproxy-router-base.yml
@@ -13,7 +13,7 @@ content:
 enabled_repos:
 - rhel-server-rpms
 - rhel-server-optional-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 from:
   builder:
   - stream: golang

--- a/images/ose-metering-ansible-operator.yml
+++ b/images/ose-metering-ansible-operator.yml
@@ -12,7 +12,7 @@ container_yaml:
 enabled_repos:
 - rhel-server-rpms
 - rhel-server-optional-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 - rhel-7-server-ansible-2.8-rpms
 from:
   builder:

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -12,7 +12,7 @@ content:
 enabled_repos:
 - rhel-server-rpms
 - rhel-fast-datapath-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 from:
   builder:
   - stream: golang

--- a/images/ose-tools.yml
+++ b/images/ose-tools.yml
@@ -9,7 +9,7 @@ distgit:
   namespace: containers
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 from:
   member: openshift-enterprise-cli
 labels:

--- a/images/presto.yml
+++ b/images/presto.yml
@@ -8,7 +8,7 @@ content:
 enabled_repos:
 - rhel-server-rpms
 - rhel-server-optional-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 from:
   builder:
   - stream: rhel

--- a/images/prom-label-proxy.yml
+++ b/images/prom-label-proxy.yml
@@ -11,9 +11,9 @@ content:
       url: git@github.com:openshift-priv/prom-label-proxy.git
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms  # required by the builder
+- rhel-server-ose-rpms-embargoed  # required by the builder
 non_shipping_repos:
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 from:
   builder:
   - stream: golang

--- a/images/thanos.yml
+++ b/images/thanos.yml
@@ -13,9 +13,9 @@ distgit:
   component: ose-thanos-container
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms  # required by the builder
+- rhel-server-ose-rpms-embargoed  # required by the builder
 non_shipping_repos:
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 from:
   builder:
   - stream: golang


### PR DESCRIPTION
- Leave our existing plashet as-is - unembargoed and mirrored  (the name of this repo matters upstream in CI, so we can't change it without a PR to openshift/release).
- remove content_sets for unembargoed repos to avoid being used in ART build or confusing elliott redundant content_set check
- Create a new group.yml entry for our embargoed plashet; do not enable reposync.
- Change ocp-build-data image metadatas 'enabled-repos' to point to the new embargoed plashet entry.