### PR TITLE
ART-2082: Only reposync unembargoed plashets

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -158,7 +158,7 @@ repos:
       s390x: rhel-7-for-system-z-optional-rpms
     reposync:
       enabled: false
-  rhel-server-ose-rpms:
+  rhel-server-ose-rpms-embargoed:
     conf:
       baseurl:
         ppc64le: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}/building-embargoed/ppc64le/os
@@ -169,8 +169,18 @@ repos:
       optional: true
       ppc64le: rhel-7-for-power-le-ose-{MAJOR}.{MINOR}-rpms
       s390x: rhel-7-for-system-z-ose-{MAJOR}.{MINOR}-rpms
+    reposync:
+      enabled: false
+  rhel-server-ose-rpms:  # for reposync and CI build only
+    conf:
+      baseurl:
+        ppc64le: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}/building/ppc64le/os
+        s390x: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}/building/s390x/os
+        x86_64: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}/building/x86_64/os
+    content_set:  # keep empty to avoid being used in ART build or confusing elliott redundant content_set check
+      optional: true
   # Included to trigger reposync of rhel-8 rpms
-  rhel-8-server-ose-rpms:
+  rhel-8-server-ose-rpms-embargoed:
     conf:
       baseurl:
         ppc64le: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el8/building-embargoed/ppc64le/os
@@ -181,6 +191,16 @@ repos:
       optional: true
       ppc64le: rhocp-{MAJOR}.{MINOR}-for-rhel-8-ppc64le-rpms
       s390x: rhocp-{MAJOR}.{MINOR}-for-rhel-8-s390x-rpms
+    reposync:
+      enabled: false
+  rhel-8-server-ose-rpms:  # for reposync and CI build only
+    conf:
+      baseurl:
+        ppc64le: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el8/building/ppc64le/os
+        s390x: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el8/building/s390x/os
+        x86_64: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el8/building/x86_64/os
+    content_set:  # keep empty to avoid being used in ART build or confusing elliott redundant content_set check
+      optional: true
   rhel-server-rhscl-rpms:
     conf:
       baseurl:

--- a/images/golang-github-prometheus-alertmanager.yml
+++ b/images/golang-github-prometheus-alertmanager.yml
@@ -11,7 +11,7 @@ content:
       url: git@github.com:openshift-priv/prometheus-alertmanager.git
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:
@@ -25,6 +25,6 @@ labels:
   vendor: Red Hat
 name: openshift/ose-prometheus-alertmanager
 non_shipping_repos:
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 owners:
 - team-monitoring@redhat.com

--- a/images/golang-github-prometheus-node_exporter.yml
+++ b/images/golang-github-prometheus-node_exporter.yml
@@ -11,7 +11,7 @@ content:
       url: git@github.com:openshift-priv/node_exporter.git
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:
@@ -26,6 +26,6 @@ labels:
   vendor: Red Hat
 name: openshift/ose-prometheus-node-exporter
 non_shipping_repos:
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 owners:
 - team-monitoring@redhat.com

--- a/images/golang-github-prometheus-prometheus.yml
+++ b/images/golang-github-prometheus-prometheus.yml
@@ -11,7 +11,7 @@ content:
       url: git@github.com:openshift-priv/prometheus.git
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:
@@ -25,6 +25,6 @@ labels:
   vendor: Red Hat
 name: openshift/ose-prometheus
 non_shipping_repos:
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 owners:
 - team-monitoring@redhat.com

--- a/images/hadoop.yml
+++ b/images/hadoop.yml
@@ -11,7 +11,7 @@ dependents:
 - ose-metering-ansible-operator
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 for_payload: false
 from:
   builder:

--- a/images/hive.yml
+++ b/images/hive.yml
@@ -11,7 +11,7 @@ dependents:
 - ose-metering-ansible-operator
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 for_payload: false
 from:
   builder:

--- a/images/ironic-hardware-inventory-recorder-image.yml
+++ b/images/ironic-hardware-inventory-recorder-image.yml
@@ -17,7 +17,7 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 - openstack-16-for-rhel-8-rpms
 for_payload: true
 from:

--- a/images/ironic-inspector.yml
+++ b/images/ironic-inspector.yml
@@ -13,7 +13,7 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 - openstack-16-for-rhel-8-rpms
 for_payload: true
 from:

--- a/images/ironic-ipa-downloader.yml
+++ b/images/ironic-ipa-downloader.yml
@@ -13,7 +13,7 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 - openstack-16-for-rhel-8-rpms
 for_payload: true
 from:

--- a/images/ironic-rhcos-downloader.yml
+++ b/images/ironic-rhcos-downloader.yml
@@ -13,7 +13,7 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 - openstack-16-for-rhel-8-rpms
 for_payload: true
 from:
@@ -22,4 +22,4 @@ name: openshift/ose-ironic-machine-os-downloader
 owners:
 - ironic-osp-owners@redhat.com
 non_shipping_repos:
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed

--- a/images/ironic-static-ip-manager.yml
+++ b/images/ironic-static-ip-manager.yml
@@ -13,7 +13,7 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: true
 from:
   stream: rhel8
@@ -21,4 +21,4 @@ name: openshift/ose-ironic-static-ip-manager
 owners:
 - ironic-osp-owners@redhat.com
 non_shipping_repos:
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed

--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -13,7 +13,7 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 - openstack-16-for-rhel-8-rpms
 for_payload: true
 from:

--- a/images/jenkins-agent-maven-35-rhel7.yml
+++ b/images/jenkins-agent-maven-35-rhel7.yml
@@ -10,7 +10,7 @@ enabled_repos:
 - rhel-server-rpms
 - rhel-server-optional-rpms
 - rhel-server-rhscl-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 for_payload: true
 from:
   member: jenkins-slave-base-rhel7

--- a/images/jenkins-agent-nodejs-10-rhel7.yml
+++ b/images/jenkins-agent-nodejs-10-rhel7.yml
@@ -8,7 +8,7 @@ content:
     path: agent-nodejs-10
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 - rhel-server-rhscl-rpms
 for_payload: false
 from:

--- a/images/jenkins-agent-nodejs-12-rhel7.yml
+++ b/images/jenkins-agent-nodejs-12-rhel7.yml
@@ -8,7 +8,7 @@ content:
     path: agent-nodejs-12
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 - rhel-server-rhscl-rpms
 for_payload: false
 from:

--- a/images/jenkins-slave-base-rhel7.yml
+++ b/images/jenkins-slave-base-rhel7.yml
@@ -8,7 +8,7 @@ content:
     path: slave-base
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 for_payload: false
 from:
   builder:

--- a/images/kuryr-cni.yml
+++ b/images/kuryr-cni.yml
@@ -14,7 +14,7 @@ enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
 - rhel-8-fast-datapath-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 - openstack-16-for-rhel-8-rpms
 for_payload: true
 from:

--- a/images/kuryr-controller.yml
+++ b/images/kuryr-controller.yml
@@ -14,7 +14,7 @@ enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
 - rhel-8-fast-datapath-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 - openstack-16-for-rhel-8-rpms
 for_payload: true
 from:

--- a/images/logging-curator5.yml
+++ b/images/logging-curator5.yml
@@ -12,7 +12,7 @@ distgit:
   namespace: containers
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 for_payload: false
 from:
   stream: python-36
@@ -30,4 +30,4 @@ push:
   - openshift/logging-curator5
   - openshift/ose-logging-curator5
 non_shipping_repos:
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed

--- a/images/logging-eventrouter.yml
+++ b/images/logging-eventrouter.yml
@@ -1,6 +1,6 @@
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 for_payload: false
 from:
   stream: rhel

--- a/images/logging-kibana5.yml
+++ b/images/logging-kibana5.yml
@@ -13,7 +13,7 @@ distgit:
 enabled_repos:
 - rhel-server-rpms
 - rhel-server-optional-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 - rhel-server-rhscl-rpms
 for_payload: false
 from:

--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -11,7 +11,7 @@ content:
 enabled_repos:
 - rhel-server-rpms
 - rhel-server-optional-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 - rhel-server-extras-rpms
 - rhel-7-server-ansible-2.9-rpms
 for_payload: false

--- a/images/openshift-enterprise-egress-dns-proxy.yml
+++ b/images/openshift-enterprise-egress-dns-proxy.yml
@@ -10,7 +10,7 @@ distgit:
   namespace: containers
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 for_payload: false
 from:
   member: openshift-enterprise-base

--- a/images/openshift-enterprise-haproxy-router.yml
+++ b/images/openshift-enterprise-haproxy-router.yml
@@ -7,7 +7,7 @@ content:
       url: git@github.com:openshift-priv/router.git
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 for_payload: true
 from:
   member: ose-haproxy-router-base

--- a/images/openshift-enterprise-service-catalog.yml
+++ b/images/openshift-enterprise-service-catalog.yml
@@ -11,7 +11,7 @@ content:
     path: images/service-catalog
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 for_payload: true
 from:
   member: openshift-enterprise-base

--- a/images/openshift-enterprise-service-idler.yml
+++ b/images/openshift-enterprise-service-idler.yml
@@ -13,7 +13,7 @@ content:
     path: images/service-idler
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 for_payload: false
 from:
   member: openshift-enterprise-base
@@ -26,6 +26,6 @@ labels:
   vendor: Red Hat
 name: openshift/ose-service-idler
 non_shipping_repos:
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 owners:
 - sross@redhat.com

--- a/images/openshift-enterprise-template-service-broker-operator.yml
+++ b/images/openshift-enterprise-template-service-broker-operator.yml
@@ -9,7 +9,7 @@ content:
 enabled_repos:
 - rhel-server-rpms
 - rhel-server-optional-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 for_payload: false
 from:
   member: openshift-enterprise-ansible-operator

--- a/images/openshift-jenkins-2.yml
+++ b/images/openshift-jenkins-2.yml
@@ -12,7 +12,7 @@ content:
     path: '2'
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:

--- a/images/ose-baremetal-installer.yml
+++ b/images/ose-baremetal-installer.yml
@@ -11,7 +11,7 @@ content:
       url: git@github.com:openshift-priv/installer.git
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:

--- a/images/ose-haproxy-router-base.yml
+++ b/images/ose-haproxy-router-base.yml
@@ -13,7 +13,7 @@ content:
 enabled_repos:
 - rhel-server-rpms
 - rhel-server-optional-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 for_payload: false
 from:
   builder:
@@ -31,4 +31,4 @@ owners:
 - aos-network-edge@redhat.com
 non_shipping_repos:
 - rhel-server-optional-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed

--- a/images/ose-metering-ansible-operator.yml
+++ b/images/ose-metering-ansible-operator.yml
@@ -15,7 +15,7 @@ enabled_repos:
 - rhel-server-rpms
 - rhel-server-optional-rpms
 - rhel-server-extras-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 - rhel-7-server-ansible-2.9-rpms
 for_payload: false
 from:

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -12,7 +12,7 @@ content:
 enabled_repos:
 - rhel-server-rpms
 - rhel-fast-datapath-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:

--- a/images/presto.yml
+++ b/images/presto.yml
@@ -11,7 +11,7 @@ dependents:
 - ose-metering-ansible-operator
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 for_payload: false
 from:
   builder:

--- a/images/thanos.yml
+++ b/images/thanos.yml
@@ -13,7 +13,7 @@ distgit:
   component: ose-thanos-container
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:
@@ -21,6 +21,6 @@ from:
   member: openshift-enterprise-base
 name: openshift/ose-thanos
 non_shipping_repos:
-- rhel-server-ose-rpms
+- rhel-server-ose-rpms-embargoed
 owners:
 - team-monitoring@redhat.com


### PR DESCRIPTION
- Leave our existing plashet as-is - unembargoed and mirrored  (the name of this repo matters upstream in CI, so we can't change it without a PR to openshift/release).
- remove content_sets for unembargoed repos to avoid being used in ART build or confusing elliott redundant content_set check
- Create a new group.yml entry for our embargoed plashet; do not enable reposync.
- Change ocp-build-data image metadatas 'enabled-repos' to point to the new embargoed plashet entry.