### PR TITLE
Remove the redundant rhel-7-server-optional-rpms content set from the Hive image.

### DIFF
--- a/images/hive.yml
+++ b/images/hive.yml
@@ -7,7 +7,6 @@ content:
       url: git@github.com:kube-reporting/hive.git
 enabled_repos:
 - rhel-server-rpms
-- rhel-server-optional-rpms
 from:
   builder:
   - stream: rhel


### PR DESCRIPTION
Starting to tackle some of the CVP content_set failures that have been popping up.

When inspecting the [sanity test log for the optional CVP tests](http://external-ci-coldstorage.datahub.redhat.com/cvp/cvp-product-test/hive-container-v4.6.0-202008061759.p0/d3fc2eda-b726-42a7-bd45-b9b6854bb29d/sanity-tests-optional-results.json), I saw the following error message:
```
        {
            "name": "content_set_check",
            "ok": false,
            "status": "FAIL",
            "description": "Content sets defined in Dist-git have to match with rpm content which is installed in the image",
            "message": "Content sets in content_sets.yml have to be correct",
            "reference_url": "https://mojo.redhat.com/docs/DOC-1023066#jive_content_id_Content_set_information",
            "logs": [
                "Checking CS of build: hive-container-v4.6.0-202008061759.p0.amd64",
                "Some content sets are redundant.",
                [
                    {
                        "nvr": "hive-container-v4.6.0-202008061759.p0",
                        "arch": "amd64",
                        "unreleased_rpms": [],
                        "not_covered_rpms": [],
                        "redundant_cs": [
                            "rhel-7-server-optional-rpms"
                        ],
                        "dist_git_cs": [
                            "rhel-7-server-optional-rpms",
                            "rhel-7-server-rpms"
                        ],
                        "suggested_content_set_additions": []
                    }
                ]
            ]
        },
```

This PR just removes that redundant content set from the list of enabled_repos.