### PR TITLE
Make rhel-8-golang-1.13 fully functional

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -4,6 +4,7 @@ arches:
 - x86_64
 - ppc64le
 - s390x
+- aarch64
 
 urls:
   brewhub: https://brewhub.engineering.redhat.com/brewhub
@@ -22,13 +23,15 @@ repos:
       extra_options:
         module_hotfixes: 1
       baseurl:
+        aarch64: http://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-4.4-rhel-8-build/latest/aarch64/
         ppc64le: http://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-4.4-rhel-8-build/latest/ppc64le/
         s390x: http://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-4.4-rhel-8-build/latest/s390x/
         x86_64: http://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-4.4-rhel-8-build/latest/x86_64/
 
     # These content sets are not used, so just putting something here
     content_set:
-      default: rhel-7-server-ose-4.2-rpms
-      ppc64le: rhel-7-for-power-le-ose-4.2-rpms
-      s390x: rhel-7-for-system-z-ose-4.2-rpms
+      default: rhocp-4.4-for-rhel-8-x86_64-rpms
+      aarch64: rhocp-4.4-for-rhel-8-aarch64-rpms
+      ppc64le: rhocp-4.4-for-rhel-8-ppc64le-rpms
+      s390x: rhocp-4.4-for-rhel-8-s390x-rpms
       optional: true

--- a/images/openshift-golang-builder.Dockerfile
+++ b/images/openshift-golang-builder.Dockerfile
@@ -1,6 +1,9 @@
 FROM openshift/ose-base:ubi8
 
 ENV SUMMARY="RHEL8 based Go builder image for OpenShift ART" \
+    container=oci \
+    GOFLAGS='-mod=vendor' \
+    GOPATH=/go \
     VERSION="1.13"
 
 LABEL summary="$SUMMARY" \
@@ -10,5 +13,8 @@ LABEL summary="$SUMMARY" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
       version="$VERSION"
 
-RUN yum install -y --setopt=tsflags=nodocs "go-toolset-$VERSION.*" && \
+RUN yum install -y --setopt=tsflags=nodocs \
+    bc diffutils file findutils gpgme git hostname lsof make rsync socat tar tree util-linux wget which zip \
+    "go-toolset-$VERSION.*" goversioninfo openssl openssl-devel systemd-devel gpgme-devel libassuan-devel && \
+    mkdir -p /go/src && \
     yum clean all -y


### PR DESCRIPTION
Since we already have 1.14 for most of 4.6 and now 1.12 for etcd, probably best if we just do 1.13 now too and avoid any future emergencies.

/assign @jupierce 