### PR TITLE
Allow etcd to specify its own golang version

### DIFF
--- a/images/ose-etcd.yml
+++ b/images/ose-etcd.yml
@@ -15,7 +15,10 @@ enabled_repos:
 - rhel-8-appstream-rpms
 from:
   builder:
-  - stream: golang
+  # IMPORTANT: etcd has unique approval to track its own etcd version. Other repos need arch
+  # approval to diverge from what kube apiserver uses for a given release.
+  # https://coreos.slack.com/archives/CB95J6R4N/p1598453188186800?thread_ts=1598449075.172000&cid=CB95J6R4N
+  - stream: etcd_golang
   member: openshift-enterprise-base
 labels:
   License: Apache 2.0

--- a/streams.yml
+++ b/streams.yml
@@ -1,9 +1,9 @@
 ---
 
 ################################################################################################
-#  STOP. HOLD. PLEASE WAIT. PLEASE READ. FAILURE TO READ WILL BE EMBARASSING FOR ART. 
+#  STOP. HOLD. PLEASE WAIT. PLEASE READ. FAILURE TO READ WILL BE EMBARASSING FOR ART.
 ################################################################################################
-# If you are about to modify this file, please know that the end result may be changing the 
+# If you are about to modify this file, please know that the end result may be changing the
 # base images for all upstream CI.
 #
 # ******IF you are about to bump ART's golang version******
@@ -12,8 +12,8 @@
 #
 # ******IF you are about to change an upstream_image name******
 # Do so only if discussed with your team lead. This field does not impact ART builds.
-# When this field is changed, it will open upstream PRs for each image using the stream 
-# in ART's ocp-build-data. i.e. if you change the upstream_image for golang, you will 
+# When this field is changed, it will open upstream PRs for each image using the stream
+# in ART's ocp-build-data. i.e. if you change the upstream_image for golang, you will
 # indirectly be responsible for openining >150 upstream PRs.
 # Details: https://docs.google.com/document/d/1vTf_Ev_9iv_myWu7ClYLlsiN54rEDIblq-90n3sNscs/edit
 #
@@ -32,38 +32,54 @@ rhel:
   # Note that it must be qualified by {MAJOR}.{MINOR} so that it installs non-CDN
   # rpms for the appropriate release.
   upstream_image: registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-{MAJOR}.{MINOR}
+
 golang:
   image: openshift/golang-builder:rhel_8_golang_1.14
   mirror: true
   upstream_image_base: registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-{MAJOR}.{MINOR}.art
-  # dptp will layer yum repos / extra packages on top of ART's image to create the 
+  # dptp will layer yum repos / extra packages on top of ART's image to create the
   # actual upstream_image. This is to allow upstream some extra helpers to build
   # tests that don't happen downstream.
   upstream_image: registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-{MAJOR}.{MINOR}
+
+
+# IMPORTANT: etcd has unique approval to track its own etcd version. Other repos need arch
+# approval to diverge from what kube apiserver uses for a given release.
+# https://coreos.slack.com/archives/CB95J6R4N/p1598453188186800?thread_ts=1598449075.172000&cid=CB95J6R4N
+etcd_golang:
+  image: openshift/golang-builder:rhel_8_golang_1.12
+  mirror: true
+  upstream_image: registry.svc.ci.openshift.org/ocp/builder:rhel-8-etcd-golang-1.12
+
 rhel-7-golang:
   image: openshift/golang-builder:1.14
   mirror: true
   upstream_image_base: registry.svc.ci.openshift.org/ocp/builder:rhel-7-golang-openshift-{MAJOR}.{MINOR}.art
-  # dptp will layer yum repos / extra packages on top of ART's image to create the 
+  # dptp will layer yum repos / extra packages on top of ART's image to create the
   # actual upstream_image. This is to allow upstream some extra helpers to build
   # tests that don't happen downstream.
   upstream_image: registry.svc.ci.openshift.org/ocp/builder:rhel-7-golang-openshift-{MAJOR}.{MINOR}
+
 ruby-25:
   image: openshift/ose-base:ubi8.ruby.25
   mirror: true
   upstream_image: registry.svc.ci.openshift.org/ocp/builder:ubi8.ruby.25
+
 python-36:
   image: openshift/ose-base:ubi8.python.36
   mirror: true
   upstream_image: registry.svc.ci.openshift.org/ocp/builder:ubi8.python.36
+
 nodejs-10:
   image: openshift/ose-base:ubi8.nodejs.10
   mirror: true
   upstream_image: registry.svc.ci.openshift.org/ocp/builder:ubi8.nodejs.10
+
 nodejs-12:
   image: openshift/ose-base:ubi8.nodejs.12
   mirror: true
   upstream_image: registry.svc.ci.openshift.org/ocp/builder:ubi8.nodejs.12
+
 # The following is only included to push an image for DPTP to start building
 # ubi7 base images with yum repos. It is probably not going to be necessary
 # in 4.6 if we successfully transition everything to rhel8.


### PR DESCRIPTION
etcd has unique approval to track its own etcd version. Other repos need arch approval to diverge from what kube apiserver uses for a given release.
ref: https://coreos.slack.com/archives/CB95J6R4N/p1598453188186800?thread_ts=1598449075.172000&cid=CB95J6R4N