### PR TITLE
Define module_hotfixes to avoid modularity errors

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -20,6 +20,8 @@ branch: rhaos-4.3-rhel-8
 repos:
   rhel-8-server-ose-build-rpms:
     conf:
+      extra_options:
+        module_hotfixes: 1
       baseurl:
         aarch64: http://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-4.3-rhel-8-build/latest/aarch64/
         ppc64le: http://download-node-02.eng.bos.redhat.com/brewroot/repos/rhaos-4.3-rhel-8-build/latest/ppc64le/


### PR DESCRIPTION
Without this, the build fails with the following error message:

```
No available modular metadata for modular package
'golang-src-1.12.12-4.module+el8.1.0+4559+87297aa9.noarch', it cannot be
installed on the system
```

/assign @jupierce

Please build after merging.