### PR TITLE
Define rhel-8-codeready-builder-rpms

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -213,6 +213,18 @@ repos:
       s390x: rhel-8-for-s390x-appstream-rpms
     reposync:
       enabled: false
+  rhel-8-codeready-builder-rpms:
+    conf:
+      baseurl:
+        ppc64le: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel8/8/ppc64le/codeready-builder/os/
+        s390x: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel8/8/s390x/codeready-builder/os/
+        x86_64: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel8/8/x86_64/codeready-builder/os/
+    content_set:
+      default: codeready-builder-for-rhel-8-x86_64-rpms
+      ppc64le: codeready-builder-for-rhel-8-ppc64le-rpms
+      s390x: codeready-builder-for-rhel-8-s390x-rpms
+    reposync:
+      enabled: false
   rhel-8-fast-datapath-rpms:
     conf:
       baseurl:


### PR DESCRIPTION
Nothing currently built by ART requires CRB, but
openshift-kni/cnf-features-deploy does for libpcap-devel.

/assign @jupierce