### PR TITLE
images/cluster-version-operator: Use Dockerfile.rhel

### DIFF
--- a/images/cluster-version-operator.yml
+++ b/images/cluster-version-operator.yml
@@ -4,7 +4,7 @@ container_yaml:
     - module: github.com/openshift/cluster-version-operator
 content:
   source:
-    dockerfile: Dockerfile.rhel7
+    dockerfile: Dockerfile.rhel
     git:
       branch:
         target: release-{MAJOR}.{MINOR}


### PR DESCRIPTION
Because we don't care if it's 7 or 8.  Catches up with openshift/cluster-version-operator@32204c00ba (openshift/cluster-version-operator#444).

Not sure if this needs to land in openshift-4.6-rhel-8 too or not.