### PR TITLE
Update dockerfile paths for baremetal-runtimecfg configurations

### DIFF
--- a/images/baremetal-runtimecfg.yml
+++ b/images/baremetal-runtimecfg.yml
@@ -4,7 +4,7 @@ container_yaml:
     - module: github.com/openshift/baremetal-runtimecfg
 content:
   source:
-    dockerfile: Dockerfile
+    dockerfile: Dockerfile.openshift
     git:
       branch:
         target: release-{MAJOR}.{MINOR}


### PR DESCRIPTION
This change is in support of bugzilla 1872080. It modifies the
configuration file for the baremetal-runtimecfg component by adjusting their
dockerfile to match the newly created "Dockerfile.openshift" file.

This change also depends on another pull request and should not be
merged until they are:
https://github.com/openshift/baremetal-runtimecfg/pull/93