### PR TITLE
Update dockerfile paths for machine-api image configurations

### DIFF
--- a/images/atomic-openshift-cluster-autoscaler.yml
+++ b/images/atomic-openshift-cluster-autoscaler.yml
@@ -4,7 +4,7 @@ container_yaml:
     - module: k8s.io/autoscaler
 content:
   source:
-    dockerfile: images/cluster-autoscaler/Dockerfile.rhel7
+    dockerfile: images/cluster-autoscaler/Dockerfile.rhel
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/baremetal-machine-controller.yml
+++ b/images/baremetal-machine-controller.yml
@@ -4,6 +4,7 @@ container_yaml:
     - module: github.com/openshift/cluster-api-provider-baremetal
 content:
   source:
+    dockerfile: Dockerfile.rhel
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/ose-aws-machine-controllers.yml
+++ b/images/ose-aws-machine-controllers.yml
@@ -4,6 +4,7 @@ container_yaml:
     - module: sigs.k8s.io/cluster-api-provider-aws
 content:
   source:
+    dockerfile: Dockerfile.rhel
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/ose-azure-machine-controllers.yml
+++ b/images/ose-azure-machine-controllers.yml
@@ -4,6 +4,7 @@ container_yaml:
     - module: sigs.k8s.io/cluster-api-provider-azure
 content:
   source:
+    dockerfile: Dockerfile.rhel
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/ose-cluster-autoscaler-operator.yml
+++ b/images/ose-cluster-autoscaler-operator.yml
@@ -4,7 +4,7 @@ container_yaml:
     - module: github.com/openshift/cluster-autoscaler-operator
 content:
   source:
-    dockerfile: Dockerfile.rhel7
+    dockerfile: Dockerfile.rhel
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/ose-cluster-machine-approver.yml
+++ b/images/ose-cluster-machine-approver.yml
@@ -4,7 +4,7 @@ container_yaml:
     - module: github.com/openshift/cluster-machine-approver
 content:
   source:
-    dockerfile: Dockerfile.rhel7
+    dockerfile: Dockerfile.rhel
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/ose-gcp-machine-controllers.yml
+++ b/images/ose-gcp-machine-controllers.yml
@@ -4,7 +4,7 @@ container_yaml:
     - module: github.com/openshift/cluster-api-provider-gcp
 content:
   source:
-    dockerfile: Dockerfile
+    dockerfile: Dockerfile.rhel
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/ose-machine-api-operator.yml
+++ b/images/ose-machine-api-operator.yml
@@ -4,7 +4,7 @@ container_yaml:
     - module: github.com/openshift/machine-api-operator
 content:
   source:
-    dockerfile: Dockerfile.rhel7
+    dockerfile: Dockerfile.rhel
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/ose-openstack-machine-controllers.yml
+++ b/images/ose-openstack-machine-controllers.yml
@@ -4,7 +4,7 @@ container_yaml:
     - module: sigs.k8s.io/cluster-api-provider-openstack
 content:
   source:
-    dockerfile: Dockerfile.rhel7
+    dockerfile: Dockerfile.rhel
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/ose-ovirt-machine-controllers.yml
+++ b/images/ose-ovirt-machine-controllers.yml
@@ -4,7 +4,7 @@ container_yaml:
     - module: github.com/openshift/cluster-api-provider-ovirt
 content:
   source:
-    dockerfile: Dockerfile
+    dockerfile: Dockerfile.rhel
     git:
       branch:
         target: release-{MAJOR}.{MINOR}

--- a/images/vertical-pod-autoscaler.yml
+++ b/images/vertical-pod-autoscaler.yml
@@ -4,7 +4,7 @@ container_yaml:
     - module: github.com/openshift/kubernetes-autoscaler
 content:
   source:
-    dockerfile: Dockerfile.rhel7
+    dockerfile: Dockerfile.rhel
     git:
       branch:
         target: release-{MAJOR}.{MINOR}


### PR DESCRIPTION
This change is in support of bugzilla 1872080. It modifies the
configuration files for the machine-api components by adjusting their
dockerfile to match the newly created "Dockerfile.rhel" files.

This change also depends on several pull requests and should not be
merged until they are:
https://github.com/openshift/machine-api-operator/pull/692
https://github.com/openshift/cluster-api-provider-gcp/pull/118
https://github.com/openshift/cluster-api-provider-aws/pull/349
https://github.com/openshift/cluster-api-provider-ovirt/pull/67
https://github.com/openshift/cluster-api-provider-openstack/pull/115
https://github.com/openshift/kubernetes-autoscaler/pull/169
https://github.com/openshift/kubernetes-autoscaler/pull/168
https://github.com/openshift/cluster-api-provider-azure/pull/161
https://github.com/openshift/cluster-api-provider-baremetal/pull/102
https://github.com/openshift/cluster-autoscaler-operator/pull/161
https://github.com/openshift/cluster-machine-approver/pull/83