### PR TITLE
ci-deps: add rhel7 fast-datapath repos

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -68,6 +68,16 @@ repos:
       default: rhel-7-server-ansible-2.8-rpms
       ppc64le: rhel-7-server-ansible-2.8-for-power-le-rpms
       s390x: rhel-7-server-ansible-2.8-for-system-z-rpms
+  rhel-fast-datapath-rpms:
+    conf:
+      baseurl:
+          ppc64le: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/power-le/7/7Server/ppc64le/fast-datapath/os/
+          s390x: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/system-z/7/7Server/s390x/fast-datapath/os/
+          x86_64: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/fast-datapath/os/
+    content_set:
+      default: rhel-7-fast-datapath-rpms
+      ppc64le: rhel-7-fast-datapath-for-power-le-rpms
+      s390x: rhel-7-fast-datapath-for-system-z-rpms
   rhel-server-extras-rpms:
     conf:
       baseurl:


### PR DESCRIPTION
To match what we provide for RHCOS.

@jupierce 