### PR TITLE
use rhel-8-golang as a base for operator-registry

### DIFF
--- a/images/operator-registry.yml
+++ b/images/operator-registry.yml
@@ -12,7 +12,7 @@ enabled_repos:
 - rhel-server-rpms
 from:
   builder:
-  - stream: golang
+  - stream: rhel-8-golang
   member: openshift-enterprise-base
 name: openshift/ose-operator-registry
 owners:


### PR DESCRIPTION
this will include the cross-compilers for mac and windows