### PR TITLE
Add special-resource-operator to ART release

### DIFF
--- a/images/special-resource-operator.yml
+++ b/images/special-resource-operator.yml
@@ -1,0 +1,20 @@
+container_yaml:
+  go:
+    modules:
+    - module: github.com/openshift-psap/special-resource-operator
+content:
+  source:
+    dockerfile: Dockerfile
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/special-resource-operator.git
+enabled_repos:
+- rhel-server-rpms
+from:
+  builder:
+  - stream: golang
+  member: openshift-enterprise-base
+name: openshift/ose-special-resource-operator
+owners:
+- openshift-psap@redhat.com


### PR DESCRIPTION
The 4.6 CI release contains:

    special-resource-operator git 659da391 sha256:e6d870f6f2b5b1680353d8336ba61666e1541bdd26ac62ceff7c686bee5efb6f

we need special-resource-operator also as part of ART releases

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>