### PR TITLE
images/cluster-version-operator: Add the over-the-air updates team as owners

### DIFF
--- a/images/cluster-version-operator.yml
+++ b/images/cluster-version-operator.yml
@@ -19,3 +19,4 @@ from:
 name: openshift/ose-cluster-version-operator
 owners:
 - crawford@redhat.com
+- aos-team-ota@redhat.com


### PR DESCRIPTION
So we get emails when Brew builds fail and on other image-maintenance tasks.

I'm not sure if @crawford wants to remain an owner alongside the team or be replaced by the team.  Until he weighs in, keeping him as a co-owner is the most conservative approach.