### PR TITLE
images: remove crawford from CVO ownership

### DIFF
--- a/images/cluster-version-operator.yml
+++ b/images/cluster-version-operator.yml
@@ -18,5 +18,4 @@ from:
   member: openshift-enterprise-base
 name: openshift/ose-cluster-version-operator
 owners:
-- crawford@redhat.com
 - aos-team-ota@redhat.com


### PR DESCRIPTION
The over-the-air updates team is the more responsive owner.