### PR TITLE
Install osxcross built libraries

### DIFF
--- a/images/openshift-golang-builder.Dockerfile
+++ b/images/openshift-golang-builder.Dockerfile
@@ -34,7 +34,10 @@ RUN [ $(go env GOARCH) != "amd64" ] || (\
     UNATTENDED=yes ./build.sh && \
     popd && \
     cp -avr cross/osxcross/target/bin/* /usr/local/bin/ && \
-    cp -avr cross/osxcross/target/SDK /usr/local/SDK && \ 
+    cp -avr cross/osxcross/target/lib/* /usr/local/lib64/ && \
+    cp -avr cross/osxcross/target/SDK /usr/local/SDK && \
+    echo /usr/local/lib64 > /etc/ld.so.conf.d/local.conf && \
+    /sbin/ldconfig && \
     rm -rf cross && \
     yum clean all -y)
 RUN rm -rf cross.tar.gz


### PR DESCRIPTION
A couple shared libraries are built and required by the osxcross
toolchain. These need to be installed and ldconfig'ed for the dependent
binaries to work.

/assign @sosiouxme