### PR TITLE
Remove openstack repos from ansible-operator

### DIFF
--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -14,8 +14,6 @@ enabled_repos:
 - rhel-8-appstream-rpms
 - rhel-8-server-ose-rpms
 - rhel-8-server-ansible-2.9-rpms
-# this image is not RHOS specific but uses some general Python RPMs built there
-- openstack-16-for-rhel-8-rpms
 from:
   builder:
   - stream: golang

--- a/images/ose-metering-ansible-operator.yml
+++ b/images/ose-metering-ansible-operator.yml
@@ -14,8 +14,6 @@ enabled_repos:
 - rhel-8-appstream-rpms
 - rhel-8-server-ose-rpms
 - rhel-8-server-ansible-2.9-rpms
-# this image is not RHOS specific but inherits some RPMs from ansible-operator
-- openstack-16-for-rhel-8-rpms
 from:
   builder:
   - member: ose-metering-helm


### PR DESCRIPTION
This didn't work for s390x, so the necessary packages have been
cross-tagged instead.

/assign @sosiouxme