### PR TITLE
Build cli and cli-artifacts with RHEL 7

### DIFF
--- a/images/openshift-enterprise-cli.yml
+++ b/images/openshift-enterprise-cli.yml
@@ -18,7 +18,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: golang
+  - stream: rhel-7-golang
   member: openshift-enterprise-base
 labels:
   License: GPLv2+

--- a/images/ose-cli-artifacts.yml
+++ b/images/ose-cli-artifacts.yml
@@ -18,7 +18,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: golang
+  - stream: rhel-7-golang
   member: openshift-enterprise-cli
 name: openshift/ose-cli-artifacts
 owners:


### PR DESCRIPTION
oc is currently dynamically linked, which is needed for gssapi support.
Dynamically linked RHEL 8 binaries will not run on RHEL 7 because of
dependencies on GLIBC_2.28 symbols.

https://github.com/openshift/oc/pull/568 needs to be merged in tandem.

/assign @jupierce 