### PR TITLE
Revert "Transition from golang 1.14 to 1.15"

### DIFF
--- a/images/operator-registry.yml
+++ b/images/operator-registry.yml
@@ -14,7 +14,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: golang-1.14
+  - stream: golang
   member: openshift-enterprise-base
 name: openshift/ose-operator-registry
 owners:

--- a/streams.yml
+++ b/streams.yml
@@ -57,7 +57,7 @@ rhel-7:
   transform: rhel-7/base-repos
   upstream_image: registry.svc.ci.openshift.org/ocp/builder:rhel-7-base-openshift-{MAJOR}.{MINOR}
 
-golang-1.14:
+golang:
   image: openshift/golang-builder:rhel_8_golang_1.14
   mirror: true
   upstream_image_base: registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-{MAJOR}.{MINOR}.art
@@ -65,7 +65,8 @@ golang-1.14:
   transform: rhel-8/golang
   upstream_image: registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-{MAJOR}.{MINOR}
 
-golang:
+# Added to mirror out a golang 1.15 version for early adoption
+golang-1.15:
   image: openshift/golang-builder:rhel_8_golang_1.15
   mirror: true
   transform: rhel-8/golang


### PR DESCRIPTION
Reverts openshift/ocp-build-data#664
PR opening tooling failed. Backing out.