### PR TITLE
[ART-2065] ose-jenkins-agent-nodejs-12: should have nodejs version in name

### DIFF
--- a/images/ose-jenkins-agent-nodejs-12.yml
+++ b/images/ose-jenkins-agent-nodejs-12.yml
@@ -20,6 +20,7 @@ labels:
   io.k8s.display-name: Jenkins Agent Nodejs
   io.openshift.tags: openshift,jenkins,agent,nodejs
   vendor: Red Hat
+# NOTE: the name in the CVO is deliberately unversioned; everywhere else is versioned.
 name: openshift/ose-jenkins-agent-nodejs
 owners:
 - openshift-dev-services+jenkins@redhat.com


### PR DESCRIPTION
@yselkowitz please confirm that renaming `jenkins-agent-nodejs-12-rhel7.yml => ose-jenkins-agent-nodejs.yml` in https://github.com/openshift/ocp-build-data/commit/86e266142baa51ded25911ad79ec773f952e3b68 was not intended. I thought we were just plain deprecating that, not re-using it for nodejs 12. However there is still a jenkins-agent-nodejs in the upstream payload, so I wasn't sure if you were trying to preserve that somehow.


-------- Commit msg:
This was incorrectly renamed from jenkins-agent-nodejs-12-rhel7 to
ose-jenkins-agent-nodejs, dropping the version.
Meanwhile ose-jenkins-agent-nodejs and component/comet repo is
deprecated (referred to unsupportable nodejs 8).
Moved to name ose-jenkins-agent-nodejs-12 as clearly intended per
https://projects.engineering.redhat.com/browse/CLOUDBLD-1986