### PR TITLE
ART-2082: Only reposync unembargoed plashets

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -78,7 +78,7 @@ repos:
     reposync:
       enabled: false
   # Included to trigger reposync of rhel-8 rpms
-  rhel-8-server-ose-rpms:
+  rhel-8-server-ose-rpms-embargoed:
     conf:
       baseurl:
         aarch64: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el8/building-embargoed/aarch64/os
@@ -91,6 +91,19 @@ repos:
       aarch64: rhocp-{MAJOR}.{MINOR}-for-rhel-8-aarch64-rpms
       ppc64le: rhocp-{MAJOR}.{MINOR}-for-rhel-8-ppc64le-rpms
       s390x: rhocp-{MAJOR}.{MINOR}-for-rhel-8-s390x-rpms
+    reposync:
+      enabled: false
+
+  rhel-8-server-ose-rpms:
+    conf:
+      baseurl:
+        aarch64: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el8/building/aarch64/os
+        ppc64le: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el8/building/ppc64le/os
+        s390x: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el8/building/s390x/os
+        x86_64: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el8/building/x86_64/os
+    content_set:  # keep empty to avoid being used in ART build or confusing elliott redundant content_set check
+      optional: true
+
   rhel-8-baseos-rpms:
     conf:
       baseurl:

--- a/images/atomic-openshift-cluster-autoscaler.yml
+++ b/images/atomic-openshift-cluster-autoscaler.yml
@@ -14,7 +14,7 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:

--- a/images/atomic-openshift-descheduler.yml
+++ b/images/atomic-openshift-descheduler.yml
@@ -12,7 +12,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: false
 from:
   builder:

--- a/images/atomic-openshift-node-problem-detector.yml
+++ b/images/atomic-openshift-node-problem-detector.yml
@@ -12,7 +12,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: false
 from:
   builder:

--- a/images/csi-attacher.yml
+++ b/images/csi-attacher.yml
@@ -12,7 +12,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:

--- a/images/csi-driver-nfs.yml
+++ b/images/csi-driver-nfs.yml
@@ -15,7 +15,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:

--- a/images/csi-livenessprobe.yml
+++ b/images/csi-livenessprobe.yml
@@ -12,7 +12,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:

--- a/images/csi-provisioner.yml
+++ b/images/csi-provisioner.yml
@@ -12,7 +12,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:

--- a/images/golang-github-openshift-oauth-proxy.yml
+++ b/images/golang-github-openshift-oauth-proxy.yml
@@ -14,7 +14,7 @@ dependents:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:

--- a/images/golang-github-prometheus-alertmanager.yml
+++ b/images/golang-github-prometheus-alertmanager.yml
@@ -12,7 +12,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:
@@ -26,6 +26,6 @@ labels:
   vendor: Red Hat
 name: openshift/ose-prometheus-alertmanager
 non_shipping_repos:
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 owners:
 - team-monitoring@redhat.com

--- a/images/golang-github-prometheus-node_exporter.yml
+++ b/images/golang-github-prometheus-node_exporter.yml
@@ -12,7 +12,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:
@@ -27,6 +27,6 @@ labels:
   vendor: Red Hat
 name: openshift/ose-prometheus-node-exporter
 non_shipping_repos:
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 owners:
 - team-monitoring@redhat.com

--- a/images/golang-github-prometheus-prometheus.yml
+++ b/images/golang-github-prometheus-prometheus.yml
@@ -12,7 +12,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:
@@ -26,6 +26,6 @@ labels:
   vendor: Red Hat
 name: openshift/ose-prometheus
 non_shipping_repos:
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 owners:
 - team-monitoring@redhat.com

--- a/images/hadoop.yml
+++ b/images/hadoop.yml
@@ -12,7 +12,7 @@ dependents:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: false
 from:
   builder:

--- a/images/ironic-hardware-inventory-recorder-image.yml
+++ b/images/ironic-hardware-inventory-recorder-image.yml
@@ -15,7 +15,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 - openstack-16-for-rhel-8-rpms
 for_payload: true
 from:

--- a/images/ironic-inspector.yml
+++ b/images/ironic-inspector.yml
@@ -11,7 +11,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 - openstack-16-for-rhel-8-rpms
 for_payload: true
 from:

--- a/images/ironic-ipa-downloader.yml
+++ b/images/ironic-ipa-downloader.yml
@@ -11,7 +11,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 - openstack-16-for-rhel-8-rpms
 for_payload: true
 from:

--- a/images/ironic-rhcos-downloader.yml
+++ b/images/ironic-rhcos-downloader.yml
@@ -11,7 +11,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 - openstack-16-for-rhel-8-rpms
 for_payload: true
 from:

--- a/images/ironic-static-ip-manager.yml
+++ b/images/ironic-static-ip-manager.yml
@@ -11,7 +11,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 - openstack-16-for-rhel-8-rpms
 for_payload: true
 from:

--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -11,7 +11,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 - openstack-16-for-rhel-8-rpms
 for_payload: true
 from:

--- a/images/kuryr-cni.yml
+++ b/images/kuryr-cni.yml
@@ -12,7 +12,7 @@ enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
 - rhel-8-fast-datapath-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 - openstack-16-for-rhel-8-rpms
 for_payload: true
 from:

--- a/images/kuryr-controller.yml
+++ b/images/kuryr-controller.yml
@@ -12,7 +12,7 @@ enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
 - rhel-8-fast-datapath-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 - openstack-16-for-rhel-8-rpms
 for_payload: true
 from:

--- a/images/logging-curator5.yml
+++ b/images/logging-curator5.yml
@@ -13,7 +13,7 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: false
 from:
   stream: python-36

--- a/images/logging-elasticsearch6.yml
+++ b/images/logging-elasticsearch6.yml
@@ -13,7 +13,7 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: false
 from:
   stream: rhel

--- a/images/logging-eventrouter.yml
+++ b/images/logging-eventrouter.yml
@@ -1,7 +1,7 @@
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: false
 from:
   stream: rhel

--- a/images/logging-fluentd.yml
+++ b/images/logging-fluentd.yml
@@ -11,7 +11,7 @@ dependents:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: false
 from:
   stream: ruby-25

--- a/images/logging-kibana6.yml
+++ b/images/logging-kibana6.yml
@@ -13,7 +13,7 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: false
 from:
   stream: nodejs-10

--- a/images/multus-cni.yml
+++ b/images/multus-cni.yml
@@ -12,7 +12,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:

--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -12,7 +12,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 - rhel-8-server-ansible-2.9-rpms
 for_payload: false
 from:

--- a/images/openshift-enterprise-cli.yml
+++ b/images/openshift-enterprise-cli.yml
@@ -14,7 +14,7 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:

--- a/images/openshift-enterprise-cluster-capacity.yml
+++ b/images/openshift-enterprise-cluster-capacity.yml
@@ -12,7 +12,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: false
 from:
   builder:

--- a/images/openshift-enterprise-egress-dns-proxy.yml
+++ b/images/openshift-enterprise-egress-dns-proxy.yml
@@ -11,7 +11,7 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: false
 from:
   member: openshift-enterprise-base

--- a/images/openshift-enterprise-haproxy-router.yml
+++ b/images/openshift-enterprise-haproxy-router.yml
@@ -8,7 +8,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: true
 from:
   member: ose-haproxy-router-base

--- a/images/openshift-enterprise-helm-operator.yml
+++ b/images/openshift-enterprise-helm-operator.yml
@@ -12,7 +12,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: false
 from:
   builder:

--- a/images/openshift-enterprise-hyperkube.yml
+++ b/images/openshift-enterprise-hyperkube.yml
@@ -14,7 +14,7 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:

--- a/images/openshift-enterprise-service-idler.yml
+++ b/images/openshift-enterprise-service-idler.yml
@@ -14,7 +14,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: false
 from:
   member: openshift-enterprise-base

--- a/images/openshift-enterprise-tests.yml
+++ b/images/openshift-enterprise-tests.yml
@@ -11,7 +11,7 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:

--- a/images/openshift-jenkins-2.yml
+++ b/images/openshift-jenkins-2.yml
@@ -13,7 +13,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:

--- a/images/ose-baremetal-installer.yml
+++ b/images/ose-baremetal-installer.yml
@@ -12,7 +12,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:

--- a/images/ose-cli-artifacts.yml
+++ b/images/ose-cli-artifacts.yml
@@ -14,7 +14,7 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:

--- a/images/ose-cluster-samples-operator.yml
+++ b/images/ose-cluster-samples-operator.yml
@@ -11,7 +11,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:

--- a/images/ose-haproxy-router-base.yml
+++ b/images/ose-haproxy-router-base.yml
@@ -13,7 +13,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: false
 from:
   builder:

--- a/images/ose-jenkins-agent-base.yml
+++ b/images/ose-jenkins-agent-base.yml
@@ -9,7 +9,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: false
 from:
   builder:

--- a/images/ose-jenkins-agent-nodejs-10.yml
+++ b/images/ose-jenkins-agent-nodejs-10.yml
@@ -9,7 +9,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: false
 from:
   member: ose-jenkins-agent-base

--- a/images/ose-jenkins-agent-nodejs-12.yml
+++ b/images/ose-jenkins-agent-nodejs-12.yml
@@ -9,7 +9,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: true
 from:
   member: ose-jenkins-agent-base

--- a/images/ose-metering-ansible-operator.yml
+++ b/images/ose-metering-ansible-operator.yml
@@ -14,7 +14,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 - rhel-8-server-ansible-2.9-rpms
 for_payload: false
 from:

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -13,7 +13,7 @@ enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
 - rhel-8-fast-datapath-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:

--- a/images/ose-sdn.yml
+++ b/images/ose-sdn.yml
@@ -14,7 +14,7 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 - rhel-8-fast-datapath-rpms
 for_payload: true
 from:

--- a/images/ose-tools.yml
+++ b/images/ose-tools.yml
@@ -10,7 +10,7 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: true
 from:
   member: openshift-enterprise-cli

--- a/images/presto.yml
+++ b/images/presto.yml
@@ -12,7 +12,7 @@ dependents:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: false
 from:
   builder:

--- a/images/prom-label-proxy.yml
+++ b/images/prom-label-proxy.yml
@@ -12,7 +12,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:
@@ -20,6 +20,6 @@ from:
   stream: rhel
 name: openshift/ose-prom-label-proxy
 non_shipping_repos:
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 owners:
 - team-monitoring@redhat.com

--- a/images/thanos.yml
+++ b/images/thanos.yml
@@ -14,7 +14,7 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms # required by the builder
+- rhel-8-server-ose-rpms-embargoed # required by the builder
 for_payload: true
 from:
   builder:
@@ -22,6 +22,6 @@ from:
   member: openshift-enterprise-base
 name: openshift/ose-thanos
 non_shipping_repos:
-- rhel-8-server-ose-rpms
+- rhel-8-server-ose-rpms-embargoed
 owners:
 - team-monitoring@redhat.com


### PR DESCRIPTION
- Leave our existing plashet as-is - unembargoed and mirrored  (the name of this repo matters upstream in CI, so we can't change it without a PR to openshift/release).
- remove content_sets for unembargoed repos to avoid being used in ART build or confusing elliott redundant content_set check
- Create a new group.yml entry for our embargoed plashet; do not enable reposync.
- Change ocp-build-data image metadatas 'enabled-repos' to point to the new embargoed plashet entry.