### PR TITLE
Add bugzilla version

### DIFF
--- a/bugzilla.yml
+++ b/bugzilla.yml
@@ -10,6 +10,9 @@ target_release:
   - "4.4.z"
   - "4.4.0"
 
+bugzilla:
+  - "4.4"
+
 filters:
   default:
     - field: "component"


### PR DESCRIPTION
Bugzilla does not accept `unspecified` as a version anymore. Making versions explicit.