### PR TITLE
Add bugzilla version

### DIFF
--- a/bugzilla.yml
+++ b/bugzilla.yml
@@ -10,6 +10,10 @@ target_release:
   - "4.6.0"
   - "4.6.z"
 
+version:
+  - "4.6"
+  - "4.6.z"
+
 filters:
   default:
     - field: "component"


### PR DESCRIPTION
Bugzilla does not accept unspecified as a version anymore. Making `version` explicit.