### PR TITLE
Add bugzilla version

### DIFF
--- a/bugzilla.yml
+++ b/bugzilla.yml
@@ -10,6 +10,10 @@ target_release:
   - "4.3.z"
   - "4.3.0"
 
+version:
+  - "4.3.z"
+  - "4.3.0"
+
 filters:
   default:
     - field: "component"


### PR DESCRIPTION
Bugzilla does not accept unspecified as a version anymore. Making `version` explicit.