### PR TITLE
Add bugzilla version

### DIFF
--- a/bugzilla.yml
+++ b/bugzilla.yml
@@ -9,6 +9,10 @@ product: "OpenShift Container Platform"
 target_release:
   - "4.2.z"
 
+version:
+  - "4.2.z"
+  - "4.2.0"
+
 filters:
   default:
     - field: "component"


### PR DESCRIPTION
Bugzilla does not accept unspecified as a version anymore. Making `version` explicit.