### PR TITLE
4.5: Add jenkins nodejs{10,12} images to payload

### DIFF
--- a/images/jenkins-agent-nodejs-10-rhel7.yml
+++ b/images/jenkins-agent-nodejs-10-rhel7.yml
@@ -10,7 +10,7 @@ enabled_repos:
 - rhel-server-rpms
 - rhel-server-ose-rpms-embargoed
 - rhel-server-rhscl-rpms
-for_payload: false
+for_payload: true
 from:
   member: jenkins-slave-base-rhel7
 labels:

--- a/images/jenkins-agent-nodejs-12-rhel7.yml
+++ b/images/jenkins-agent-nodejs-12-rhel7.yml
@@ -10,7 +10,7 @@ enabled_repos:
 - rhel-server-rpms
 - rhel-server-ose-rpms-embargoed
 - rhel-server-rhscl-rpms
-for_payload: false
+for_payload: true
 from:
   member: jenkins-slave-base-rhel7
 labels:


### PR DESCRIPTION
I believe we intend to ship these two images as part of the payload, and
not as part of the extras. There is no operator governing these jenkins
agents.

As a background, these agent images were introduced after the GA. And
apparently did not make it in the payload, as we have previously based
our payload images on the previous payload images, which later got
codified with PR #559.

I am not sure if this is the right action to take in this phase of the
release, so consider this a conversation starter.