### PR TITLE
Add jenkins-agent-base to payload

### DIFF
--- a/images/ose-jenkins-agent-base.yml
+++ b/images/ose-jenkins-agent-base.yml
@@ -10,7 +10,7 @@ enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
 - rhel-8-server-ose-rpms-embargoed
-for_payload: false
+for_payload: true
 from:
   builder:
   - stream: golang


### PR DESCRIPTION
cluster-samples-operator needs this to overwrite the jenkins-agent-base
imagestream like it already does for the agents themselves:

https://github.com/openshift/cluster-samples-operator/pull/331

/cherry-pick openshift-4.6
