### PR TITLE
Add bugzilla component to VPA image metadata

### DIFF
--- a/images/vertical-pod-autoscaler.yml
+++ b/images/vertical-pod-autoscaler.yml
@@ -22,6 +22,8 @@ from:
   builder:
   - stream: golang
   member: openshift-enterprise-base
+maintainer:
+  component: Node
 name: openshift/ose-vertical-pod-autoscaler-rhel8
 owners:
 - joesmith@redhat.com


### PR DESCRIPTION
According to https://docs.google.com/document/d/1V_DGuVqbo6CUro0RC86THQWZPrQMwvtDr0YQ0A75QbQ I should add the component to my image metadata if I can't add it to the root `OWNERS` file. Since VPA lives in the https://github.com/openshift/kubernetes-autoscaler/ repo along with cluster autoscaler, we can't put the component in the root `OWNERS` since the two images are part of different compoents.