### PR TITLE
fix(operator-registry): switch to go 1.14

### DIFF
--- a/images/operator-registry.yml
+++ b/images/operator-registry.yml
@@ -14,7 +14,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: golang
+  - stream: golang-1.14
   member: openshift-enterprise-base
 name: openshift/ose-operator-registry
 owners:


### PR DESCRIPTION
An issue in Go 1.15 causes darwin cross-compilation to fail when debug info is enabled (see https://github.com/golang/go/issues/40974#issuecomment-701429581).

Switching back to 1.14 until this can be resolved.