### PR TITLE
images: change scheduler-operator owner to aos-master mailing list

### DIFF
--- a/images/ose-cluster-kube-scheduler-operator.yml
+++ b/images/ose-cluster-kube-scheduler-operator.yml
@@ -19,4 +19,4 @@ from:
   member: openshift-enterprise-base
 name: openshift/ose-cluster-kube-scheduler-operator
 owners:
-- aos-pod@redhat.com
+- aos-master@redhat.com


### PR DESCRIPTION
Node (formerly Pod) team doesn't not own this.

FYI @sttts @rphillips 