### PR TITLE
4.7: Support multi-target rpm build and golang buildroot check - 4.7

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -103,8 +103,8 @@ repos:
         x86_64: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el8/building/x86_64/os
     content_set:  # keep empty to avoid being used in ART build or confusing elliott redundant content_set check
       optional: true
-  
-  # The installer team working with rhel-7 worker nodes needs rhel-7 rpms reposync'd. 
+
+  # The installer team working with rhel-7 worker nodes needs rhel-7 rpms reposync'd.
   rhel-server-ose-rpms:
     conf:
       baseurl:
@@ -204,3 +204,5 @@ scan_freshness:
   release_regex: '(?x) ^ (\d\d\d\d) (\d\d) (\d\d) (\d\d)'
   threshold_hours: 6
 csv_namespace: openshift
+# whether and how to check if all buildroots have consistent versions of golang compilers (rpm build only)
+check_golang_versions: exact  # "x.y" (default): only major and minor version; "exact": the z-version must be the same; "no": do not check

--- a/rpms/openshift-ansible.yml
+++ b/rpms/openshift-ansible.yml
@@ -12,3 +12,5 @@ owners:
 distgit:
   # this is needed for RHEL 7 worker node support
   branch: rhaos-{MAJOR}.{MINOR}-rhel-7
+targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-7-candidate  # this is needed for RHEL 7 worker node support

--- a/rpms/openshift-clients.yml
+++ b/rpms/openshift-clients.yml
@@ -9,6 +9,7 @@ name: openshift-clients
 owners:
 - aos-master@redhat.com
 distgit:
-  # this is needed for RHEL 7 worker node support
-  # aos-cd-jobs' el8-rebuilds causes this to be rebuilt for RHEL 8 for RHCOS
   branch: rhaos-{MAJOR}.{MINOR}-rhel-7
+targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-7-candidate  # this is needed for RHEL 7 worker node support
+- rhaos-{MAJOR}.{MINOR}-rhel-8-candidate

--- a/rpms/openshift.yml
+++ b/rpms/openshift.yml
@@ -15,6 +15,7 @@ owners:
 - aos-master@redhat.com
 - ccoleman@redhat.com
 distgit:
-  # this is needed for RHEL 7 worker node support
-  # aos-cd-jobs' el8-rebuilds causes this to be rebuilt for RHEL 8 for RHCOS
   branch: rhaos-{MAJOR}.{MINOR}-rhel-7
+targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-7-candidate  # this is needed for RHEL 7 worker node support
+- rhaos-{MAJOR}.{MINOR}-rhel-8-candidate


### PR DESCRIPTION
- Build multi-target (el7 and el8) rpms with Doozer
- Assert buildroots for multi-target builds have correct golang compilers

Requires https://github.com/openshift/doozer/pull/320 and https://github.com/openshift/doozer/pull/324.