### PR TITLE
Ignore bz component CNF Platform Validation

### DIFF
--- a/bugzilla.yml
+++ b/bugzilla.yml
@@ -24,6 +24,9 @@ filters:
     - field: "component"
       operator: "notequals"
       value: "Migration Tooling"
+    - field: "component"
+      operator: "notequals"
+      value: "CNF Platform Validation"
   security:
     - field: "component"
       operator: "notequals"
@@ -34,3 +37,6 @@ filters:
     - field: "component"
       operator: "notequals"
       value: "Migration Tooling"
+    - field: "component"
+      operator: "notequals"
+      value: "CNF Platform Validation"


### PR DESCRIPTION
The bugzilla component `CNF Platform Validation` is managed by its own errata flow. Instruct ARTs tooling to ignore bugs with this component. As requested here: https://coreos.slack.com/archives/CJARLA942/p1605001593172200