### PR TITLE
openshift-4.7: Fix build of ptp-operator-must-gather

### DIFF
--- a/images/ptp-operator-must-gather.yml
+++ b/images/ptp-operator-must-gather.yml
@@ -4,11 +4,12 @@ container_yaml:
     - module: github.com/openshift/ptp-operator
 content:
   source:
-    dockerfile: must-gather/Dockerfile.rhel7
+    dockerfile: Dockerfile.rhel7
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ptp-operator.git
+    path: must-gather
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms


### PR DESCRIPTION
Image builds have been failing with the following error:
```
--> COPY --from=builder /go/src/github.com/openshift/ptp-operator/must-gather/collection-scripts/* /usr/bin/
API error (404): lstat /var/lib/docker/overlay2/.../go/src/github.com/openshift/ptp-operator/must-gather/collection-scripts/: no such file or directory
```

This sets the working directory as expected.

Test run initiated here: https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fcustom/1718/console