### PR TITLE
[golang-1.13] Add RHEL 7 pulp repo to get signed content

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -20,6 +20,17 @@ branch: rhaos-4.4-rhel-7
 # When the buildroot is bumped for a new version of go, the RPM should land in this repository
 # and the image will need to be rebuilt.
 repos:
+  # this needs to be named alphabetically first to pick up signed RPMs
+  rhel-7-server-rpms:
+    conf:
+      baseurl:
+        ppc64le: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/power-le/7/7Server/ppc64le/os/
+        s390x: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/system-z/7/7Server/s390x/os/
+        x86_64: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/os/
+    content_set:
+      default: rhel-7-server-rpms
+      ppc64le: rhel-7-for-power-le-rpms
+      s390x: rhel-7-for-system-z-rpms
   rhel-server-ose-build-rpms:
     conf:
       baseurl:

--- a/images/openshift-golang-builder.yml
+++ b/images/openshift-golang-builder.yml
@@ -10,6 +10,7 @@ content:
 distgit:
   branch: rhaos-4.4-rhel-7
 enabled_repos:
+- rhel-7-server-rpms
 - rhel-server-ose-build-rpms
 from:
   image: openshift/ose-base:ubi7


### PR DESCRIPTION
RHEL 7.9 initscripts, which is a dependency of s390utils, added a
dependency on bc.  While s390utils and its dependencies is removed from
the base image kickstart, bc wasn't added to the list of removals.  The
result is a signed bc ending up in the base image only on s390x.  When
bc is then installed in golang-builder from the brew buildroot which is
unsigned, a mismatch results and the build fails.

Adding a RHEL pulp repo, which is signed, and making it first
alphabetically should give it priority in yum mitigating the mismatch.

/assign @sosiouxme
