### PR TITLE
Add ose-cluster-kube-descheduler-operator as a dependent of descheduler

### DIFF
--- a/images/atomic-openshift-descheduler.yml
+++ b/images/atomic-openshift-descheduler.yml
@@ -25,3 +25,5 @@ labels:
 name: openshift/ose-descheduler
 owners:
 - rgudimet@redhat.com
+dependents:
+- ose-cluster-kube-descheduler-operator


### PR DESCRIPTION
Got this error when building stage operator metadata for 4.4.31:

`Command returned non-zero exit status: Error running [/mnt/workspace/jenkins/working/aos-cd-builds/build%2Fappregistry] skopeo inspect docker://registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-descheduler:v4.4.0-202011132159.p0. See debug log.` (https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fappregistry/7753/console)

I didn't check the error in details, but it seems to me the operator `ose-cluster-kube-descheduler-operator` has a reference to an old version of operand `atomic-openshift-descheduler`.

To make sure the operator is always rebuilt once its operand is rebuilt, add the operator as a dependent.