### PR TITLE
Support multi-target rpm build and golang buildroot check - 4.5

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -37,7 +37,6 @@ build_profiles:
     default:
       targets:
       - rhaos-{MAJOR}.{MINOR}-rhel-7-candidate
-      - rhaos-{MAJOR}.{MINOR}-rhel-8-candidate
 
 default_image_build_profile: unsigned
 default_rpm_build_profile: default
@@ -297,3 +296,5 @@ scan_freshness:
   release_regex: '(?x) ^ (\d\d\d\d) (\d\d) (\d\d) (\d\d)'
   threshold_hours: 6
 csv_namespace: openshift
+# whether and how to check if all buildroots have consistent versions of golang compilers (rpm build only)
+check_golang_versions: exact  # "x.y" (default): only major and minor version; "exact": the z-version must be the same; "no": do not check

--- a/rpms/machine-config-daemon.yml
+++ b/rpms/machine-config-daemon.yml
@@ -10,3 +10,5 @@ owners:
   - coreos-devel@redhat.com
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-8-candidate

--- a/rpms/openshift-clients.yml
+++ b/rpms/openshift-clients.yml
@@ -8,3 +8,8 @@ content:
 name: openshift-clients
 owners:
 - aos-master@redhat.com
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-7
+targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-7-candidate  # this is needed for RHEL 7 worker node support
+- rhaos-{MAJOR}.{MINOR}-rhel-8-candidate

--- a/rpms/openshift-kuryr.yml
+++ b/rpms/openshift-kuryr.yml
@@ -10,3 +10,5 @@ content:
 name: openshift-kuryr
 distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-8
+targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-8-candidate

--- a/rpms/openshift.yml
+++ b/rpms/openshift.yml
@@ -11,3 +11,8 @@ name: openshift
 owners:
 - aos-master@redhat.com
 - ccoleman@redhat.com
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-7
+targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-7-candidate  # this is needed for RHEL 7 worker node support
+- rhaos-{MAJOR}.{MINOR}-rhel-8-candidate


### PR DESCRIPTION
- Build multi-target (el7 and el8) rpms with Doozer
- Assert buildroots for multi-target builds have correct golang compilers

Requires https://github.com/openshift/doozer/pull/324 and https://github.com/openshift/doozer/pull/324.