### PR TITLE
[openshift-4.7] Enable remaining OLM operators

### DIFF
--- a/images/cluster-nfd-operator.yml
+++ b/images/cluster-nfd-operator.yml
@@ -1,4 +1,3 @@
-mode: disabled
 container_yaml:
   go:
     modules:

--- a/images/clusterresourceoverride-operator.yml
+++ b/images/clusterresourceoverride-operator.yml
@@ -1,4 +1,3 @@
-mode: disabled
 container_yaml:
   go:
     modules:

--- a/images/vertical-pod-autoscaler-operator.yml
+++ b/images/vertical-pod-autoscaler-operator.yml
@@ -1,4 +1,3 @@
-mode: disabled
 container_yaml:
   go:
     modules:


### PR DESCRIPTION
Manifests have all been updated for 4.7:

https://github.com/openshift/cluster-nfd-operator/commit/5d809ee4cd461c628b45be90588e2659a04f4ed3
https://github.com/openshift/cluster-resource-override-admission-operator/commit/b13fb5ce67cbe4ad271027a140e186636fcb4ba4
https://github.com/openshift/vertical-pod-autoscaler-operator/commit/d64a5ca5ff684e65813e9e0edc8f3f7311d63580
