### PR TITLE
Revert "[ART-2473] Un-wip images/ose-special-resource-operator.yml"

### DIFF
--- a/images/ose-special-resource-operator.yml
+++ b/images/ose-special-resource-operator.yml
@@ -1,3 +1,4 @@
+mode: wip
 container_yaml:
   go:
     modules:


### PR DESCRIPTION
This reverts commit be893ba920fe17b0602f0c47d6dedf7b21e83a4b.

The version currently installed is not setting ClusterOperator status, which is breaking nightly promotion.  Drop it until they have green CI showing their operator functioning as expected.