### PR TITLE
Enable manila images on ppc64le

### DIFF
--- a/images/csi-driver-manila-operator.yml
+++ b/images/csi-driver-manila-operator.yml
@@ -1,6 +1,6 @@
-# OpenStack Manila does not yet have multi-arch support
 arches:
 - x86_64
+- ppc64le
 container_yaml:
   go:
     modules:

--- a/images/csi-driver-manila.yml
+++ b/images/csi-driver-manila.yml
@@ -1,6 +1,6 @@
-# OpenStack Manila is not yet supported on ppc64le
 arches:
 - x86_64
+- ppc64le
 container_yaml:
   go:
     modules:

--- a/images/csi-driver-nfs.yml
+++ b/images/csi-driver-nfs.yml
@@ -1,6 +1,6 @@
-# Only supported in conjunction with Manila CSI driver
 arches:
 - x86_64
+- ppc64le
 container_yaml:
   go:
     modules:


### PR DESCRIPTION
Although running Manila on RHOS for IBM Power is not currently 
supported, OpenStack IPI causes the CSO to require the operator to be 
present, even if just to report that Manila is not enabled on OpenStack. 
Therefore, these need to be built on Power but will not be supported.
