### PR TITLE
Rename debug-network image to network-tools

### DIFF
--- a/images/ose-network-tools.yml
+++ b/images/ose-network-tools.yml
@@ -1,0 +1,23 @@
+mode: wip
+container_yaml:
+  go:
+    modules:
+    - module: github.com/openshift/network-tools
+content:
+  source:
+    dockerfile: Dockerfile.rhel7
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/network-tools.git
+enabled_repos:
+- rhel-8-baseos-rpms
+- rhel-8-appstream-rpms
+for_payload: false
+from:
+  builder:
+  - stream: golang
+  member: openshift-enterprise-base
+name: openshift/ose-network-tools
+owners:
+- aos-networking-staff@redhat.com


### PR DESCRIPTION
The aim is to rename `openshift/debug-network` to `openshift/network-tools` and to move the content of the repos.

Related `openshift/release` commit: https://github.com/openshift/release/pull/14261