### PR TITLE
ART-2589: Adapt to Pulp hostname change - 4.6

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -64,10 +64,10 @@ repos:
   rhel-8-server-ansible-2.9-rpms:
     conf:
       baseurl:
-        aarch64: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/layered/rhel8/aarch64/ansible/2.9/os/
-        ppc64le: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/layered/rhel8/ppc64le/ansible/2.9/os/
-        s390x: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/layered/rhel8/s390x/ansible/2.9/os/
-        x86_64: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/layered/rhel8/x86_64/ansible/2.9/os/
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/aarch64/ansible/2.9/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/ppc64le/ansible/2.9/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/s390x/ansible/2.9/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/x86_64/ansible/2.9/os/
     content_set:
       default: ansible-2.9-for-rhel-8-x86_64-rpms
       aarch64: ansible-2.9-for-rhel-8-aarch64-rpms
@@ -116,10 +116,10 @@ repos:
   rhel-8-baseos-rpms:
     conf:
       baseurl:
-        aarch64: http://pulp.dist.prod.ext.phx2.redhat.com/content/eus/rhel8/8.2/aarch64/baseos/os/
-        ppc64le: http://pulp.dist.prod.ext.phx2.redhat.com/content/eus/rhel8/8.2/ppc64le/baseos/os/
-        s390x: http://pulp.dist.prod.ext.phx2.redhat.com/content/eus/rhel8/8.2/s390x/baseos/os/
-        x86_64: http://pulp.dist.prod.ext.phx2.redhat.com/content/eus/rhel8/8.2/x86_64/baseos/os/
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.2/aarch64/baseos/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.2/ppc64le/baseos/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.2/s390x/baseos/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.2/x86_64/baseos/os/
     content_set:
       default: rhel-8-for-x86_64-baseos-eus-rpms
       aarch64: rhel-8-for-aarch64-baseos-eus-rpms
@@ -130,10 +130,10 @@ repos:
   rhel-8-appstream-rpms:
     conf:
       baseurl:
-        aarch64: http://pulp.dist.prod.ext.phx2.redhat.com/content/eus/rhel8/8.2/aarch64/appstream/os/
-        ppc64le: http://pulp.dist.prod.ext.phx2.redhat.com/content/eus/rhel8/8.2/ppc64le/appstream/os/
-        s390x: http://pulp.dist.prod.ext.phx2.redhat.com/content/eus/rhel8/8.2/s390x/appstream/os/
-        x86_64: http://pulp.dist.prod.ext.phx2.redhat.com/content/eus/rhel8/8.2/x86_64/appstream/os/
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.2/aarch64/appstream/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.2/ppc64le/appstream/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.2/s390x/appstream/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.2/x86_64/appstream/os/
     content_set:
       default: rhel-8-for-x86_64-appstream-eus-rpms
       aarch64: rhel-8-for-aarch64-appstream-eus-rpms
@@ -144,9 +144,9 @@ repos:
   rhel-8-fast-datapath-rpms:
     conf:
       baseurl:
-        x86_64: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/layered/rhel8/x86_64/fast-datapath/os/
-        ppc64le: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/layered/rhel8/ppc64le/fast-datapath/os/
-        s390x: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/layered/rhel8/s390x/fast-datapath/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/x86_64/fast-datapath/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/ppc64le/fast-datapath/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/s390x/fast-datapath/os/
         # FDP has yet to be released for aarch64
         # aarch64: http://download.lab.bos.redhat.com/rcm-guest/puddles/Multi-Arch/Fast-DataPath/EL8-Production/latest/aarch64/os/
         # [lmeyer] multi-arch releases might lag behind x86_64, which may require pointing at pre-release MA composes.
@@ -164,11 +164,11 @@ repos:
   openstack-16-for-rhel-8-rpms:
     conf:
       baseurl:
-        ppc64le: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/layered/rhel8/ppc64le/openstack/16/os/
-        x86_64: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/layered/rhel8/x86_64/openstack/16/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/ppc64le/openstack/16/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/x86_64/openstack/16/os/
         # XXX: aarch64 and s390x don't exist, point it at something that exists so yum doesn't choke
-        s390x: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/layered/rhel8/x86_64/openstack/16/os/
-        aarch64: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/layered/rhel8/x86_64/openstack/16/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/x86_64/openstack/16/os/
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/x86_64/openstack/16/os/
     content_set:
       default: openstack-16-for-rhel-8-x86_64-rpms
       ppc64le: openstack-16-for-rhel-8-ppc64le-rpms


### PR DESCRIPTION
pulp.dist.prod.ext.phx2.redhat.com -> rhsm-pulp.corp.redhat.com