### PR TITLE
Build operator-registry with golang-1.15

### DIFF
--- a/images/operator-registry.yml
+++ b/images/operator-registry.yml
@@ -12,7 +12,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: golang-1.14
+  - stream: golang
   member: openshift-enterprise-base
 name: openshift/ose-operator-registry
 owners:

--- a/streams.yml
+++ b/streams.yml
@@ -57,14 +57,6 @@ rhel-7:
   transform: rhel-7/base-repos
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-7-base-openshift
 
-golang-1.14:
-  image: openshift/golang-builder:rhel_8_golang_1.14
-  mirror: true
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-{MAJOR}.{MINOR}.art
-  # The transform will layer yum repos & extra CI specific configuration on top of the ART image.
-  transform: rhel-8/golang
-  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-{MAJOR}.{MINOR}
-
 golang:
   image: openshift/golang-builder:rhel_8_golang_1.15
   mirror: true


### PR DESCRIPTION
The necessary build fix and CI Dockerfile update have already been 
merged in https://github.com/operator-framework/operator-registry/pull/541 .﻿
