### PR TITLE
SDN-1492: Network-tools: Change dockerfile path

### DIFF
--- a/images/ose-network-tools.yml
+++ b/images/ose-network-tools.yml
@@ -4,7 +4,7 @@ container_yaml:
     - module: github.com/openshift/network-tools
 content:
   source:
-    dockerfile: Dockerfile.rhel7
+    dockerfile: Dockerfile
     git:
       branch:
         target: release-{MAJOR}.{MINOR}


### PR DESCRIPTION
The present Dockerfile path is named as `Dockerfile.rhel7` whereas it is
using the rhel8 builder. This is really confusing and in future would end
up in more confusion with each version.

This patch changes art to use the default `Dockerfile` in the repo so that the
file name doesn't cause confusion with the image type or version.

This was also a part of the suggestion of the security review for the repo (to have the main file named as `Dockerfile`).