### PR TITLE
SDN-1492: Fix ART builds for network-tools

### DIFF
--- a/images/ose-network-tools.yml
+++ b/images/ose-network-tools.yml
@@ -16,7 +16,8 @@ for_payload: false
 from:
   builder:
   - stream: golang
-  member: openshift-enterprise-base
+  - member: ose-ovn-kubernetes
+  member: ose-tools
 name: openshift/ose-network-tools
 owners:
 - aos-networking-staff@redhat.com


### PR DESCRIPTION
In https://github.com/openshift/ocp-build-data/pull/808 the Dockerfile was changed, but the base image information for building
was not changed and now the ocp-build-data configuration is not in sync which causes
build failures. This patch updates the image stream information.