### PR TITLE
Add patch and xz for all

### DIFF
--- a/images/openshift-golang-builder.Dockerfile
+++ b/images/openshift-golang-builder.Dockerfile
@@ -15,8 +15,34 @@ LABEL summary="$SUMMARY" \
       version="$VERSION"
 
 RUN yum install -y --setopt=tsflags=nodocs \
-    bc diffutils file findutils gpgme git hostname lsof make rsync socat tar tree util-linux wget which zip python3 \
-    "go-toolset-$VERSION.*" goversioninfo openssl openssl-devel systemd-devel gpgme-devel libassuan-devel && \
+        bc \
+        diffutils \
+        file \
+        findutils \
+        git \
+        "go-toolset-$VERSION.*" \
+        goversioninfo \
+        gpgme \
+        gpgme-devel \
+        hostname \
+        libassuan-devel \
+        libtool \
+        lsof \
+        make \
+        openssl \
+        openssl-devel \
+        patch \
+        python3 \
+        rsync \
+        socat \
+        systemd-devel \
+        tar \
+        tree \
+        util-linux \
+        wget \
+        which \
+        xz \
+        zip && \
     mkdir -p /go/src && \
     yum clean all -y
 
@@ -25,7 +51,7 @@ RUN [ $(go env GOARCH) != "amd64" ] || (\
     # only install cross-compiler dependencies on amd64
     yum install -y --setopt=tsflags=nodocs \
     # Required packages for mac cross-compilation
-    patch xz llvm-toolset libtool cmake3 gcc-c++ libxml2-devel \
+    llvm-toolset cmake3 gcc-c++ libxml2-devel \
     # Required packages for windows cross-compilation
     glibc mingw64-gcc && \
     # compile macos cross-compilers


### PR DESCRIPTION
Someone [ran into an issue](https://coreos.slack.com/archives/CB95J6R4N/p1611283490047400) where builds would succeed on amd64, but fail on s390x and ppc64le. The dockerfile had a dependency on patch. 

This PR moves some general purpose packages to all images, to minimize the risk of this type of surprise.