### PR TITLE
ose-docker-builder: add rhel-server-extras-rpms repo

### DIFF
--- a/images/openshift-enterprise-builder.yml
+++ b/images/openshift-enterprise-builder.yml
@@ -10,6 +10,7 @@ content:
       url: git@github.com:openshift-priv/builder.git
 enabled_repos:
 - rhel-server-rpms
+- rhel-server-extras-rpms
 - rhel-server-optional-rpms
 for_payload: true
 from:


### PR DESCRIPTION
4.5 openshift-enterprise-builder is constantly failing. By looking at the build http://download.eng.bos.redhat.com/brewroot/work/tasks/8842/34488842/x86_64.log, runc-1.0.0-71.rhaos4.5.git5101761.el7.x86_64 requires  container-selinux >= 2:2.2-2 which doesn’t exist in our buildroot.

By looking at errata https://errata.devel.redhat.com/package/show/container-selinux, container-selinux package is in the rhel7 extras repo. I think we can try enable the rhel-server-rpms repo in our ocp-build-data.