### PR TITLE
ose-docker-builder: add rhel-server-extras-rpms repo

### DIFF
--- a/images/openshift-enterprise-builder.yml
+++ b/images/openshift-enterprise-builder.yml
@@ -10,6 +10,7 @@ content:
       url: git@github.com:openshift-priv/builder.git
 enabled_repos:
 - rhel-server-rpms
+- rhel-server-extras-rpms
 - rhel-server-optional-rpms
 - rhel-server-ose-rpms-embargoed
 for_payload: true


### PR DESCRIPTION
4.4 openshift-enterprise-builder is constantly failing. By looking at the build http://download.eng.bos.redhat.com/brewroot/work/tasks/8717/34488717/x86_64.log, runc-1.0.0-69.rhaos4.4.git81f3917.el7.x86_64 requires  container-selinux >= 2:2.2-2 which doesn’t exist in our buildroot.

It fails since this commit: https://github.com/openshift/builder/commit/88207d7723686867aef8e1fafdfc6aa334fdf9df
By looking at errata https://errata.devel.redhat.com/package/show/container-selinux, container-selinux package is in the rhel7 extras repo. I think we can try enable the rhel-server-rpms repo in our ocp-build-data.