### PR TITLE
Fix missing changes from 4.7 in 4.8

### DIFF
--- a/images/openshift-kubernetes-nmstate-handler.yml
+++ b/images/openshift-kubernetes-nmstate-handler.yml
@@ -25,7 +25,7 @@ from:
   builder:
   - stream: golang
   member: openshift-enterprise-base
-name: openshift/ose-kubernetes-nmstate-handler
+name: openshift/ose-kubernetes-nmstate-handler-rhel8
 owners:
 - asegurap@redhat.com
 - bcrochet@redhat.com

--- a/images/openshift-kubernetes-nmstate-handler.yml
+++ b/images/openshift-kubernetes-nmstate-handler.yml
@@ -13,6 +13,8 @@ content:
     - action: replace
       match: microdnf
       replacement: yum
+dependents:
+- openshift-kubernetes-nmstate-operator
 distgit:
   component: openshift-kubernetes-nmstate-handler-rhel-8-container
 enabled_repos:

--- a/images/openshift-kubernetes-nmstate-operator.yml
+++ b/images/openshift-kubernetes-nmstate-operator.yml
@@ -20,7 +20,7 @@ from:
   builder:
   - stream: golang
   member: openshift-enterprise-base
-name: openshift/ose-kubernetes-nmstate-operator
+name: openshift/kubernetes-nmstate-rhel8-operator
 owners:
 - asegurap@redhat.com
 - bcrochet@redhat.com

--- a/images/operator-registry.yml
+++ b/images/operator-registry.yml
@@ -12,7 +12,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: golang-1.14
+  - stream: golang
   member: openshift-enterprise-base
 name: openshift/ose-operator-registry
 owners:

--- a/streams.yml
+++ b/streams.yml
@@ -108,6 +108,7 @@ etcd_golang:
   image: openshift/golang-builder:rhel_8_golang_1.12
   mirror: true
   # No transform required as etcd does not yum install any packages.
+  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-etcd-golang-1.12
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-etcd-golang-1.12
 
 rhel-7-golang:
@@ -123,19 +124,23 @@ rhel-7-golang:
 ruby-25:
   image: openshift/ose-base:ubi8.ruby.25
   mirror: true
+  upstream_image_base: registry.ci.openshift.org/ocp/builder:ubi8.ruby.25
   upstream_image: registry.ci.openshift.org/ocp/builder:ubi8.ruby.25
 
 python-36:
   image: openshift/ose-base:ubi8.python.36
   mirror: true
+  upstream_image_base: registry.ci.openshift.org/ocp/builder:ubi8.python.36
   upstream_image: registry.ci.openshift.org/ocp/builder:ubi8.python.36
 
 nodejs-10:
   image: openshift/ose-base:ubi8.nodejs.10
   mirror: true
+  upstream_image_base: registry.ci.openshift.org/ocp/builder:ubi8.nodejs.10
   upstream_image: registry.ci.openshift.org/ocp/builder:ubi8.nodejs.10
 
 nodejs-14:
   image: openshift/ose-base:ubi8.nodejs.14
   mirror: true
+  upstream_image_base: registry.ci.openshift.org/ocp/builder:ubi8.nodejs.14
   upstream_image: registry.ci.openshift.org/ocp/builder:ubi8.nodejs.14

--- a/streams.yml
+++ b/streams.yml
@@ -65,14 +65,6 @@ rhel-7-ci-build-root:
   transform: rhel-7/ci-build-root
   upstream_image: registry.ci.openshift.org/openshift/release:rhel-7-release-openshift-{MAJOR}.{MINOR}
 
-golang-1.14:
-  image: openshift/golang-builder:rhel_8_golang_1.14
-  mirror: true
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-{MAJOR}.{MINOR}.art
-  # The transform will layer yum repos & extra CI specific configuration on top of the ART image.
-  transform: rhel-8/golang
-  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-{MAJOR}.{MINOR}
-
 golang:
   image: openshift/golang-builder:rhel_8_golang_1.15
   mirror: true


### PR DESCRIPTION
- kube-nmstate-handler: set operator as dependent
- kube-nmstate: internal names should match external
- Migrate to app.ci for upstream Dockerfiles
- Build operator-registry with golang 1.15

/assign @jupierce
