### PR TITLE
Build egress-router-cni for both RHEL 7 and 8

### DIFF
--- a/images/egress-router-cni.yml
+++ b/images/egress-router-cni.yml
@@ -18,6 +18,7 @@ for_payload: true
 from:
   builder:
   - stream: golang
+  - stream: rhel-7-golang
   member: openshift-enterprise-base
 name: openshift/ose-egress-router-cni
 owners:


### PR DESCRIPTION
This is in the same category as the Multus images which are extracted on
to the node by the cluster-network-operator, and therefore must be built
twice for compatibility with both BYO RHEL and RHCOS.

This depends on https://github.com/openshift/egress-router-cni/pull/33

/cc @dougbtv
/hold
