### PR TITLE
4.8: Remove local-storage-static-provisioner from payload

### DIFF
--- a/images/local-storage-static-provisioner.yml
+++ b/images/local-storage-static-provisioner.yml
@@ -15,7 +15,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-for_payload: true
+for_payload: false
 from:
   builder:
   - stream: golang


### PR DESCRIPTION
I think none of the images in the payload depend on this image. This
commit moves `local-storage-static-provisioner` to the place where
local-storage-operator and its descendants are.

@jsafrane does this sound right to you?