### PR TITLE
Bug 1930360: fluentd is unable to send logs to Elasticsearch because it can't authenticate to the es-proxy

### DIFF
--- a/images/logging-fluentd.yml
+++ b/images/logging-fluentd.yml
@@ -8,14 +8,15 @@ content:
     path: fluentd
 dependents:
 - cluster-logging-operator
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-8
 enabled_repos:
-- rhel-server-rpms
-- rhel-server-rhscl-rpms
+- rhel-8-baseos-rpms
+- rhel-8-appstream-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: false
 from:
-  builder:
-  - stream: ruby-25
-  stream: rhel
+  stream: rhel8-ruby-25
 labels:
   License: GPLv2+
   io.k8s.description: Fluentd container for collecting of container logs
@@ -25,7 +26,3 @@ labels:
 name: openshift/ose-logging-fluentd
 owners:
 - team-logging@redhat.com
-push:
-  repos:
-  - openshift/logging-fluentd
-  - openshift/ose-logging-fluentd

--- a/streams.yml
+++ b/streams.yml
@@ -9,8 +9,8 @@ rhel-8-golang:
   image: openshift/golang-builder:rhel_8_golang_1.13
 elasticsearch:
   image: openshift/ose-base:elasticsearch
-ruby-25:
-  image: rhscl/ruby-25-rhel7
+rhel8-ruby-25:
+  image: openshift/ose-base:rhel8.2.els.ruby.25
 nodejs-6:
   image: openshift/ose-base:rhscl.nodejs.6.rhel7
 nodejs-10:


### PR DESCRIPTION
Make RHEL8 the base image for logging-fluentd