### PR TITLE
[4.8] Enable aarch64 builds

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -8,6 +8,7 @@ arches:
 - x86_64
 - ppc64le
 - s390x
+- aarch64
 
 operator_image_ref_mode: manifest-list
 
@@ -219,10 +220,8 @@ repos:
         x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/x86_64/fast-datapath/os/
         ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/ppc64le/fast-datapath/os/
         s390x: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/s390x/fast-datapath/os/
-        # Trying to solve the problem of a missing repomd.xml
-        # See: https://github.com/openshift/release/pull/17851
-        # See: https://github.com/openshift/os/pull/541#issuecomment-823601083
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/aarch64/fast-datapath/os/
+        # FDP has yet to be released for aarch64
+        aarch64: http://download.lab.bos.redhat.com/rcm-guest/puddles/Multi-Arch/Fast-DataPath/EL8-Production/latest/aarch64/os/
         # [lmeyer] multi-arch releases might lag behind x86_64, which may require pointing at pre-release MA composes.
         # however this must be a temporary solution only; will cause mismatches after further releases if left that way.
         # ppc64le: http://download.lab.bos.redhat.com/rcm-guest/puddles/Multi-Arch/Fast-DataPath/EL8-Production/latest/ppc64le/os/
@@ -281,6 +280,7 @@ image_build_log_scanner:
   - x86_64.log
   - s390x.log
   - ppc64le.log
+  - aarch64.log
   - task_failed.log
   - orchestrator.log
 scan_freshness:

--- a/images/openshift-enterprise-cli-alt.yml
+++ b/images/openshift-enterprise-cli-alt.yml
@@ -1,3 +1,8 @@
+# These arches require compatibility with RHEL 7
+arches:
+- x86_64
+- ppc64le
+- s390x
 container_yaml:
   go:
     modules:
@@ -33,7 +38,5 @@ labels:
   vendor: Red Hat
 name: openshift/ose-cli-alt
 payload_name: cli
-arches:
-- x86_64
 owners:
 - aos-master@redhat.com

--- a/images/ose-aws-ebs-csi-driver-operator.yml
+++ b/images/ose-aws-ebs-csi-driver-operator.yml
@@ -1,5 +1,6 @@
 arches:
 - x86_64
+- aarch64
 container_yaml:
   go:
     modules:

--- a/images/ose-aws-ebs-csi-driver.yml
+++ b/images/ose-aws-ebs-csi-driver.yml
@@ -1,5 +1,6 @@
 arches:
 - x86_64
+- aarch64
 container_yaml:
   go:
     modules:

--- a/images/ose-aws-machine-controllers.yml
+++ b/images/ose-aws-machine-controllers.yml
@@ -1,5 +1,6 @@
 arches:
 - x86_64
+- aarch64
 container_yaml:
   go:
     modules:

--- a/images/ose-aws-pod-identity-webhook.yml
+++ b/images/ose-aws-pod-identity-webhook.yml
@@ -1,5 +1,6 @@
 arches:
 - x86_64
+- aarch64
 container_yaml:
   go:
     modules:

--- a/images/ose-cli-artifacts-alt.yml
+++ b/images/ose-cli-artifacts-alt.yml
@@ -1,3 +1,8 @@
+# These arches require compatibility with RHEL 7
+arches:
+- x86_64
+- ppc64le
+- s390x
 container_yaml:
   go:
     modules:
@@ -22,8 +27,6 @@ from:
   member: openshift-enterprise-cli
 name: openshift/ose-cli-artifacts-alt
 payload_name: cli-artifacts
-arches:
-- x86_64
 owners:
 - ccoleman@redhat.com
 - aos-master@redhat.com

--- a/streams.yml
+++ b/streams.yml
@@ -56,6 +56,7 @@ etcd_golang:
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-etcd-golang-1.12
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-etcd-golang-1.12
 
+# This image must only be used by -alt images, as this image cannot be built for aarch64.
 rhel-7-golang:
   image: openshift/golang-builder:1.16
   mirror: true


### PR DESCRIPTION
This is the initial attempt to enable aarch64 builds downstream.

A few caveats:
* When we tried to build cli/cli-artifacts to RHEL8 in 4.6, we ran into issues because it is dynamically linked and won't run on a RHEL7 userspace ("GLIBC_2.28 not found").  Those will have to be built statically instead (PR forthcoming).
* The multus/CNI images build binaries with both RHEL7 and RHEL8.  For now, I disabled them, and either they will stay that way (provided that we can do without), or a different method of providing those binaries for RHEL7 worker nodes will need to be found.
* ose-base:ubi8.nodejs.14 requires a coordinated bump with console to ubi8/nodejs-14:1-21 to fix crashes on ARM.

/cc @sosiouxme 
/hold
until we get an answer on cli/cli-artifacts and bump nodejs.