### PR TITLE
Bug 1935732: Update jenkins agent maven for 4.8

### DIFF
--- a/images/ose-jenkins-agent-maven.yml
+++ b/images/ose-jenkins-agent-maven.yml
@@ -5,7 +5,7 @@ content:
       branch:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/jenkins.git
-    path: agent-maven-3.5
+    path: agent-maven
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms


### PR DESCRIPTION
This is part of an effort to use version agnostic naming in the https://github.com/openshift/jenkins repo.
And as we are moving to maven 3.6 this change is necessary.