### PR TITLE
Re-enable the remaining operators in 4.8

### DIFF
--- a/images/clusterresourceoverride-operator.yml
+++ b/images/clusterresourceoverride-operator.yml
@@ -1,5 +1,3 @@
-# [lmeyer] disabled until upstream is configured for 4.8
-mode: disabled
 container_yaml:
   go:
     modules:

--- a/images/clusterresourceoverride.yml
+++ b/images/clusterresourceoverride.yml
@@ -9,9 +9,8 @@ content:
       branch:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-resource-override-admission.git
-## [lmeyer] disabled until upstream is configured for 4.8
-#dependents:
-#- clusterresourceoverride-operator
+dependents:
+- clusterresourceoverride-operator
 distgit:
   component: ose-clusterresourceoverride-container
 enabled_repos:

--- a/images/kube-rbac-proxy.yml
+++ b/images/kube-rbac-proxy.yml
@@ -9,9 +9,8 @@ content:
       branch:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/kube-rbac-proxy.git
-## [lmeyer] disabled until upstream is configured for 4.8
-#dependents:
-#- ptp-operator
+dependents:
+- ptp-operator
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms

--- a/images/linuxptp-daemon.yml
+++ b/images/linuxptp-daemon.yml
@@ -9,9 +9,8 @@ content:
       branch:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/linuxptp-daemon.git
-## [lmeyer] disabled until upstream is configured for 4.8
-#dependents:
-#- ptp-operator
+dependents:
+- ptp-operator
 distgit:
   component: ose-linuxptp-daemon-container
 enabled_repos:

--- a/images/ptp-operator.yml
+++ b/images/ptp-operator.yml
@@ -1,5 +1,3 @@
-# [lmeyer] disabled until upstream is configured for 4.8
-mode: disabled
 container_yaml:
   go:
     modules:


### PR DESCRIPTION
- Re-enable clusterresourceoverride-operator after https://github.com/openshift/cluster-resource-override-admission-operator/pull/57
- Re-enable ptp-operator after https://github.com/openshift/ptp-operator/pull/100

Please verify that those are correct before merging this.
