### PR TITLE
Re-enable CRO operator for 4.8

### DIFF
--- a/images/clusterresourceoverride-operator.yml
+++ b/images/clusterresourceoverride-operator.yml
@@ -1,5 +1,3 @@
-# [lmeyer] disabled until upstream is configured for 4.8
-mode: disabled
 container_yaml:
   go:
     modules:

--- a/images/clusterresourceoverride.yml
+++ b/images/clusterresourceoverride.yml
@@ -9,9 +9,8 @@ content:
       branch:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-resource-override-admission.git
-## [lmeyer] disabled until upstream is configured for 4.8
-#dependents:
-#- clusterresourceoverride-operator
+dependents:
+- clusterresourceoverride-operator
 distgit:
   component: ose-clusterresourceoverride-container
 enabled_repos:


### PR DESCRIPTION
Now that openshift/cluster-resource-override-admission-operator#57 has merged, 
re-enable ART builds of CRO operator.