### PR TITLE
images: Update the 4.8 OLM configuration(s) to use the downstream monorepo

### DIFF
--- a/images/operator-lifecycle-manager.yml
+++ b/images/operator-lifecycle-manager.yml
@@ -4,11 +4,11 @@ container_yaml:
     - module: github.com/operator-framework/operator-lifecycle-manager
 content:
   source:
-    dockerfile: Dockerfile
+    dockerfile: operator-lifecycle-manager.Dockerfile
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
-      url: git@github.com:operator-framework/operator-lifecycle-manager.git
+      url: git@github.com:openshift-priv/operator-framework-olm.git
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms

--- a/images/operator-registry.yml
+++ b/images/operator-registry.yml
@@ -1,11 +1,14 @@
+container_yaml:
+  go:
+    modules:
+    - module: github.com/operator-framework/operator-registry
 content:
   source:
+    dockerfile: operator-registry.Dockerfile
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
-      url: git@github.com:operator-framework/operator-registry.git
-    pkg_managers:
-    - gomod
+      url: git@github.com:openshift-priv/operator-framework-olm.git
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms


### PR DESCRIPTION
Update the existing OLM image configuration and update the Dockerfile name and the source upstream repository.

/hold