### PR TITLE
streams.yml: RHEL 8 builds use go 1.16 now

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -66,32 +66,23 @@ rhel-7-ci-build-root:
   upstream_image: registry.ci.openshift.org/openshift/release:rhel-7-release-openshift-{MAJOR}.{MINOR}
 
 golang:
-  image: openshift/golang-builder:rhel_8_golang_1.15
+  image: openshift/golang-builder:rhel_8_golang_1.16
   mirror: true
   transform: rhel-8/golang
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-{MAJOR}.{MINOR}.art
+  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-{MAJOR}.{MINOR}.art
   # dptp will layer yum repos / extra packages on top of ART's image to create the
   # actual upstream_image. This is to allow upstream some extra helpers to build
   # tests that don't happen downstream.
-  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-{MAJOR}.{MINOR}
+  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-{MAJOR}.{MINOR}
 
 # This is image is not used by ART. It is an artifact required in upstream CI to build unit tests.
 # Our transform is designed to create a buildconfig atop a specific golang version, layering on
 # packages that upstream has traditionally had present in its build_roots.
-rhel-8-golang-1.14-ci-build-root:
+rhel-8-golang-ci-build-root:
   image: not_applicable
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-{MAJOR}.{MINOR}
+  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-{MAJOR}.{MINOR}
   transform: rhel-8/ci-build-root
-  upstream_image: registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.14-openshift-{MAJOR}.{MINOR}
-
-# This is image is not used by ART. It is an artifact required in upstream CI to build unit tests.
-# Our transform is designed to create a buildconfig atop a specific golang version, layering on
-# packages that upstream has traditionally had present in its build_roots.
-rhel-8-golang-1.15-ci-build-root:
-  image: not_applicable
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-{MAJOR}.{MINOR}
-  transform: rhel-8/ci-build-root
-  upstream_image: registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.15-openshift-{MAJOR}.{MINOR}
+  upstream_image: registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.16-openshift-{MAJOR}.{MINOR}
 
 # IMPORTANT: etcd has unique approval to track its own etcd version. Other repos need arch
 # approval to diverge from what kube apiserver uses for a given release.


### PR DESCRIPTION
ref. https://issues.redhat.com/browse/ART-2732