### PR TITLE
openshift-4.8: Update Dockerfile for pod yaml

### DIFF
--- a/images/openshift-enterprise-pod.yml
+++ b/images/openshift-enterprise-pod.yml
@@ -1,15 +1,11 @@
-container_yaml:
-  go:
-    modules:
-    - module: github.com/openshift/images/pod
-      path: pod
 content:
   source:
-    dockerfile: pod/Dockerfile.rhel
+    dockerfile: Dockerfile.Rhel
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
-      url: git@github.com:openshift-priv/images.git
+      url: git@github.com:openshift-priv/kubernetes.git
+    path: build/pause
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms


### PR DESCRIPTION
Update the openshift-enterprise-pod.yaml to
point to the Dockerfile under openshift/k8s/build/pause
so we build a pod image containing the pause.c binary
bringing down the pod image size from ~250MB to ~1MB.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>