### PR TITLE
Remove "vmware" prefix from CSI operator and driver

### DIFF
--- a/images/ose-vmware-vsphere-csi-driver-operator.yml
+++ b/images/ose-vmware-vsphere-csi-driver-operator.yml
@@ -17,6 +17,6 @@ from:
   builder:
   - stream: golang
   member: openshift-enterprise-base
-name: openshift/ose-vmware-vsphere-csi-driver-operator
+name: openshift/ose-vsphere-csi-driver-operator
 owners:
 - aos-storage-staff@redhat.com

--- a/images/ose-vmware-vsphere-csi-driver.yml
+++ b/images/ose-vmware-vsphere-csi-driver.yml
@@ -17,6 +17,6 @@ from:
   builder:
   - stream: golang
   member: openshift-enterprise-base
-name: openshift/ose-vmware-vsphere-csi-driver
+name: openshift/ose-vsphere-csi-driver
 owners:
 - aos-storage-staff@redhat.com


### PR DESCRIPTION
CC @openshift/storage

This is the second step described here: https://docs.ci.openshift.org/docs/how-tos/onboarding-a-new-component/#removing-or-renaming-an-image-from-an-openshift-release-image