### PR TITLE
Build rhel-8-golang-1.16 with RHEL 8.3

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -43,14 +43,14 @@ repos:
   rhel-8-appstream-rpms:
     conf:
       baseurl:
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.2/aarch64/appstream/os/
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.2/ppc64le/appstream/os/
-        s390x: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.2/s390x/appstream/os/
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.2/x86_64/appstream/os/
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/aarch64/appstream/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/appstream/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/
     content_set:
-      default: rhel-8-for-x86_64-appstream-eus-rpms
-      aarch64: rhel-8-for-aarch64-appstream-eus-rpms
-      ppc64le: rhel-8-for-ppc64le-appstream-eus-rpms
-      s390x: rhel-8-for-s390x-appstream-eus-rpms
+      default: rhel-8-for-x86_64-appstream-rpms
+      aarch64: rhel-8-for-aarch64-appstream-rpms
+      ppc64le: rhel-8-for-ppc64le-appstream-rpms
+      s390x: rhel-8-for-s390x-appstream-rpms
     reposync:
       enabled: false

--- a/images/openshift-golang-builder.Dockerfile
+++ b/images/openshift-golang-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi8:8.3
+FROM registry.redhat.io/ubi8:latest
 
 ARG GOPATH
 ENV SUMMARY="RHEL8 based Go builder image for OpenShift ART" \

--- a/images/openshift-golang-builder.Dockerfile
+++ b/images/openshift-golang-builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/ose-base:rhel8.2.els.rhel
+FROM registry.redhat.io/ubi8:8.3
 
 ARG GOPATH
 ENV SUMMARY="RHEL8 based Go builder image for OpenShift ART" \
@@ -14,7 +14,8 @@ LABEL summary="$SUMMARY" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
       version="$VERSION"
 
-RUN yum install -y --setopt=tsflags=nodocs \
+RUN yum update -y && \
+    yum install -y --setopt=tsflags=nodocs \
         bc \
         diffutils \
         file \

--- a/streams.yml
+++ b/streams.yml
@@ -1,3 +1,5 @@
 ---
 rhel8:
-  image: openshift/ose-base:ubi8
+  # the most recent release at present. since we yum update this, maybe it does not need to float.
+  # but it is important that we not build from unreleased builds.
+  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi8:8.3-297

--- a/streams.yml
+++ b/streams.yml
@@ -1,5 +1,3 @@
 ---
 rhel8:
-  # the most recent release at present. since we yum update this, maybe it does not need to float.
-  # but it is important that we not build from unreleased builds.
   image: registry-proxy.engineering.redhat.com/rh-osbs/ubi8:8.3-297

--- a/streams.yml
+++ b/streams.yml
@@ -1,3 +1,3 @@
 ---
 rhel8:
-  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi8:8.3-297
+  image: registry.redhat.io/ubi8:latest


### PR DESCRIPTION
1.15 (and earlier) are locked to 8.2 because 4.6 is, but 1.16 is only for
4.8+ and therefore can use the latest.  Once we move to 8.4, this will
need to be updated again.

/cc @sosiouxme
