### PR TITLE
vsphere syncer: add missing "-driver-"

### DIFF
--- a/images/vmware-vsphere-syncer.yml
+++ b/images/vmware-vsphere-syncer.yml
@@ -19,6 +19,6 @@ from:
   builder:
   - stream: golang
   member: openshift-enterprise-base
-name: openshift/ose-vsphere-csi-syncer
+name: openshift/ose-vsphere-csi-driver-syncer
 owners:
 - aos-storage-staff@redhat.com


### PR DESCRIPTION
Trying to fix this error: https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/releasestream/4.8.0-0.nightly/release/4.8.0-0.nightly-2021-04-12-222417