### PR TITLE
Build 4.8 with RHEL 8.4 Beta

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -138,20 +138,20 @@ repos:
   rhel-8-baseos-rpms:
     conf:
       baseurl:
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/aarch64/baseos/os/
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/
-        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/baseos/os/
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/aarch64/baseos/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/ppc64le/baseos/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/s390x/baseos/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/x86_64/baseos/os/
       ci_alignment:
         profiles:
         - el8
         localdev:
           enabled: true
     content_set:
-      default: rhel-8-for-x86_64-baseos-rpms
-      aarch64: rhel-8-for-aarch64-baseos-rpms
-      ppc64le: rhel-8-for-ppc64le-baseos-rpms
-      s390x: rhel-8-for-s390x-baseos-rpms
+      default: rhel-8-for-x86_64-baseos-beta-rpms
+      aarch64: rhel-8-for-aarch64-baseos-beta-rpms
+      ppc64le: rhel-8-for-ppc64le-baseos-beta-rpms
+      s390x: rhel-8-for-s390x-baseos-beta-rpms
     reposync:
       enabled: false
 
@@ -178,38 +178,38 @@ repos:
   rhel-8-rt-rpms:
     conf:
       baseurl:
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/rt/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/x86_64/rt/os/
         # other arches don't exist, pointing at something that exists
-        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/rt/os/
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/rt/os/
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/rt/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/x86_64/rt/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/x86_64/rt/os/
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/x86_64/rt/os/
       ci_alignment:
         profiles:
         - el8
         localdev:
           enabled: true
     content_set:
-      default: rhel-8-for-x86_64-rt-rpms
+      default: rhel-8-for-x86_64-rt-beta-rpms
       # don't have content set for other arches
       optional: true
 
   rhel-8-appstream-rpms:
     conf:
       baseurl:
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/aarch64/appstream/os/
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/
-        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/appstream/os/
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/aarch64/appstream/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/ppc64le/appstream/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/s390x/appstream/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/x86_64/appstream/os/
       ci_alignment:
         profiles:
         - el8
         localdev:
           enabled: true
     content_set:
-      default: rhel-8-for-x86_64-appstream-rpms
-      aarch64: rhel-8-for-aarch64-appstream-rpms
-      ppc64le: rhel-8-for-ppc64le-appstream-rpms
-      s390x: rhel-8-for-s390x-appstream-rpms
+      default: rhel-8-for-x86_64-appstream-beta-rpms
+      aarch64: rhel-8-for-aarch64-appstream-beta-rpms
+      ppc64le: rhel-8-for-ppc64le-appstream-beta-rpms
+      s390x: rhel-8-for-s390x-appstream-beta-rpms
     reposync:
       enabled: false
 

--- a/images/driver-toolkit.yml
+++ b/images/driver-toolkit.yml
@@ -8,7 +8,7 @@ content:
     modifications:
     - action: replace
       match: "ARG RHEL_VERSION=''"
-      replacement: "ARG RHEL_VERSION='8.3'"
+      replacement: "ARG RHEL_VERSION='8.4'"
 
     # Uncomment the following sections to pin specific kernel versions
 

--- a/streams.yml
+++ b/streams.yml
@@ -69,7 +69,7 @@ rhel-7-golang:
 rhel8:
   # the most recent release at present. since we yum update this, maybe it does not need to float.
   # but it is important that we not build from unreleased builds.
-  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi8:8.3-297
+  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi8:8.4-159
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-openshift-{MAJOR}.{MINOR}.art
   mirror: true
 

--- a/streams.yml
+++ b/streams.yml
@@ -75,6 +75,6 @@ rhel8:
 
 nodejs:
   # the most recent release with precise nodejs 14 version we need.
-  image: ubi8/nodejs-14:1-21.1615199885
+  image: ubi8/nodejs-14:1-30
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-openshift-nodejs-base-{MAJOR}.{MINOR}.art
   mirror: true


### PR DESCRIPTION
RHCOS 4.8 is currently building as such, this would do the same for OCP.
Whether this is a good idea at this point or not is a different question.

/hold
/cc @sosiouxme @jupierce

