### PR TITLE
[4.8] Fix enterprise-pod build

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -155,6 +155,26 @@ repos:
     reposync:
       enabled: false
 
+  rhel-8-codeready-builder-rpms:
+    conf:
+      baseurl:
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/aarch64/codeready-builder/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/ppc64le/codeready-builder/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/codeready-builder/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/codeready-builder/os/
+      ci_alignment:
+        profiles:
+        - el8
+        localdev:
+          enabled: true
+    content_set:
+      default: codeready-builder-for-rhel-8-x86_64-rpms
+      aarch64: codeready-builder-for-rhel-8-aarch64-rpms
+      ppc64le: codeready-builder-for-rhel-8-ppc64le-rpms
+      s390x: codeready-builder-for-rhel-8-s390x-rpms
+    reposync:
+      enabled: false
+
   rhel-8-rt-rpms:
     conf:
       baseurl:

--- a/images/openshift-enterprise-pod.yml
+++ b/images/openshift-enterprise-pod.yml
@@ -9,6 +9,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
+- rhel-8-codeready-builder-rpms
 for_payload: true
 from:
   builder:
@@ -24,5 +25,7 @@ labels:
   io.openshift.tags: openshift,pod
   vendor: Red Hat
 name: openshift/ose-pod
+non_shipping_repos:
+- rhel-8-codeready-builder-rpms
 owners:
 - aos-pod@redhat.com


### PR DESCRIPTION
Since https://github.com/openshift/kubernetes/pull/633 and
https://github.com/openshift/ocp-build-data/pull/873, builds for
`openshift-enterprise-pod` started to fail because `glibc-static` could
not get installed. This commit adds the rhel-8 repository for the
glibc-static rpm.