### PR TITLE
4.5 Add nodejs12 image to payload

### DIFF
--- a/images/jenkins-agent-nodejs-12-rhel7.yml
+++ b/images/jenkins-agent-nodejs-12-rhel7.yml
@@ -10,7 +10,7 @@ enabled_repos:
 - rhel-server-rpms
 - rhel-server-ose-rpms-embargoed
 - rhel-server-rhscl-rpms
-for_payload: false
+for_payload: true
 from:
   member: jenkins-slave-base-rhel7
 labels:
@@ -20,6 +20,6 @@ labels:
   io.k8s.display-name: Jenkins Agent Nodejs
   io.openshift.tags: openshift,jenkins,agent,nodejs
   vendor: Red Hat
-name: openshift/jenkins-agent-nodejs-12-rhel7
+name: openshift/ose-jenkins-agent-nodejs
 owners:
 - openshift-dev-services+jenkins@redhat.com


### PR DESCRIPTION
...and name it as the [long forgotten nodejs8 image](https://github.com/openshift/ocp-build-data/commit/8e45baece769bec15a427c083c7a7a401f599c07#diff-c93f6b07e45b2147145f673f148c3cd2b10f98e3e23ab70b00a0a39ade7dbad8L23)

This is to address failures like https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/releasestream/4.5.0-0.nightly/release/4.5.0-0.nightly-2021-04-19-171118

Discussion in [thread](https://coreos.slack.com/archives/CB95J6R4N/p1618811457110800).