### PR TITLE
Use Beta repos for CRB as well

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -158,20 +158,20 @@ repos:
   rhel-8-codeready-builder-rpms:
     conf:
       baseurl:
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/aarch64/codeready-builder/os/
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/ppc64le/codeready-builder/os/
-        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/codeready-builder/os/
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/codeready-builder/os/
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/aarch64/codeready-builder/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/ppc64le/codeready-builder/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/s390x/codeready-builder/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/x86_64/codeready-builder/os/
       ci_alignment:
         profiles:
         - el8
         localdev:
           enabled: true
     content_set:
-      default: codeready-builder-for-rhel-8-x86_64-rpms
-      aarch64: codeready-builder-for-rhel-8-aarch64-rpms
-      ppc64le: codeready-builder-for-rhel-8-ppc64le-rpms
-      s390x: codeready-builder-for-rhel-8-s390x-rpms
+      default: codeready-builder-beta-for-rhel-8-x86_64-rpms
+      aarch64: codeready-builder-beta-for-rhel-8-aarch64-rpms
+      ppc64le: codeready-builder-beta-for-rhel-8-ppc64le-rpms
+      s390x: codeready-builder-beta-for-rhel-8-s390x-rpms
     reposync:
       enabled: false
 


### PR DESCRIPTION
This too should be reverted after RHEL 8.4 GA.

The addition of the CRB repo to get glibc-static for pod snuck in while
the 8.4 Beta PR was pending.

/assign @sosiouxme
