### PR TITLE
Bug 1954881: update manifests location for NFD

### DIFF
--- a/images/cluster-nfd-operator.yml
+++ b/images/cluster-nfd-operator.yml
@@ -22,5 +22,5 @@ owners:
 - openshift-psap@redhat.com
 update-csv:
   bundle-dir: '{MAJOR}.{MINOR}/'
-  manifests-dir: manifests/olm-catalog
+  manifests-dir: manifests/
   registry: image-registry.openshift-image-registry.svc:5000


### PR DESCRIPTION
relates to: https://github.com/openshift/cluster-nfd-operator/pull/157
Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>