### PR TITLE
openshift-3.11: node-problem-detector branch

### DIFF
--- a/images/atomic-openshift-node-problem-detector.yml
+++ b/images/atomic-openshift-node-problem-detector.yml
@@ -2,7 +2,7 @@ content:
   source:
     git:
       branch:
-        target: master
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift/node-problem-detector.git
     path: images
 enabled_repos:

--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -2,7 +2,7 @@ content:
   source:
     git:
       branch:
-        target: master
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift/ose-ovn-kubernetes.git
 enabled_repos:
 - rhel-fast-datapath-rpms

--- a/rpms/atomic-openshift-node-problem-detector.yml
+++ b/rpms/atomic-openshift-node-problem-detector.yml
@@ -2,7 +2,7 @@ content:
   source:
     git:
       branch:
-        target: release-3.11
+        target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift/node-problem-detector.git
     specfile: node-problem-detector.spec
 name: atomic-openshift-node-problem-detector

--- a/rpms/atomic-openshift-node-problem-detector.yml
+++ b/rpms/atomic-openshift-node-problem-detector.yml
@@ -2,7 +2,7 @@ content:
   source:
     git:
       branch:
-        target: master
+        target: release-3.11
       url: git@github.com:openshift/node-problem-detector.git
     specfile: node-problem-detector.spec
 name: atomic-openshift-node-problem-detector


### PR DESCRIPTION
Change the github branch of node-problem-detector from master to
release-3.11. Direct reason is a current build failure where the 3.11
golang does not recognize the `-mod` flag.