### PR TITLE
Fix modifier matchers

### DIFF
--- a/images/openshift-enterprise-node.yml
+++ b/images/openshift-enterprise-node.yml
@@ -16,16 +16,16 @@ content:
       replacement: atomic-openshift-node
 
     - action: replace
-      match: rpm -V $INSTALL_PKGS &&
-      replacement:
+      match: 'rpm -V $INSTALL_PKGS '
+      replacement: ': '
 
     - action: replace
-      match: 'yum install -y centos-release-ceph-luminous && '
-      replacement: ''
+      match: 'yum install -y centos-release-ceph-luminous '
+      replacement: ': '
 
     - action: replace
-      match: 'rpm -V centos-release-ceph-luminous && '
-      replacement: ''
+      match: 'rpm -V centos-release-ceph-luminous '
+      replacement: ': '
 
     path: images/node
 enabled_repos:

--- a/images/openshift-enterprise.yml
+++ b/images/openshift-enterprise.yml
@@ -6,11 +6,11 @@ content:
       match: INSTALL_PKGS="origin ceph-common"
       replacement: INSTALL_PKGS="atomic-openshift ceph-common"
     - action: replace
-      match: 'yum install -y centos-release-ceph-luminous && '
-      replacement: ''
+      match: 'yum install -y centos-release-ceph-luminous '
+      replacement: ': '
     - action: replace
-      match: 'rpm -V centos-release-ceph-luminous && '
-      replacement: ''
+      match: 'rpm -V centos-release-ceph-luminous '
+      replacement: ': '
     path: images/origin
 enabled_repos:
 - rhel-7-server-rhceph-3-tools-rpms


### PR DESCRIPTION
Somehow, some modifiers do not match anymore. Not really sure why, but
in the Dockerfile in distgit the chained commands are prepended with
`&&`, rather than appearing in the end.

This change replaces the command with the truthy, noop shell command
`:`, leaving the `&&` in place.