### PR TITLE
Fix ose-ovn-kubernetes build

### DIFF
--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -10,8 +10,6 @@ enabled_repos:
 - rhel-server-optional-rpms
 - rhel-server-ose-rpms-embargoed
 from:
-  builder:
-  - stream: golang
   member: openshift-base-rhel7
 labels:
   License: GPLv2+


### PR DESCRIPTION
Commit 4d9d4c89510eff205027cc7966a42d305afeee5d changes the build branch from `master`
to `release-3.11`. The Dockerfile in `release-3.11` doesn't use the golang builder.