### PR TITLE
Fix 3.11 ose-console build

### DIFF
--- a/modifications/update-console-sources
+++ b/modifications/update-console-sources
@@ -46,7 +46,7 @@ dg_repo="${DISTGIT_REPO:-${PWD}}"
 dry_run="${DRY_RUN:-false}"
 #
 # NodeJS builder image to use (may need local pull/tag since brew-pulp is insecure)
-builder_img="${BUILDER_IMAGE:-brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888/rhscl/nodejs-8-rhel7:1}"
+builder_img="${BUILDER_IMAGE:-registry-proxy.engineering.redhat.com/rh-osbs/rhscl-nodejs-8-rhel7:1}"
 
 longopts=help,dg-repo:,dg-branch:,dry-run,builder-img:
 options=hr:t:di:


### PR DESCRIPTION
Brew-pulp was deprecated long ago. Changing to registry-proxy.engineering.