### PR TITLE
Revert to previous advisories

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -12,10 +12,10 @@ arches:
 operator_image_ref_mode: manifest-list
 
 advisories:
-  image: 76152
-  rpm: 76151
-  extras: 76153
-  metadata: 76154
+  image: 76100
+  rpm: 76099
+  extras: 76101
+  metadata: 76102
   # security:
 
 signing_advisory: 68848


### PR DESCRIPTION
This is to fix what was the result of running prepare-release again.