### PR TITLE
Add openstack repo for tests

### DIFF
--- a/images/openshift-enterprise-tests.yml
+++ b/images/openshift-enterprise-tests.yml
@@ -9,6 +9,7 @@ content:
 distgit:
   namespace: containers
 enabled_repos:
+- openstack-16-for-rhel-8-rpms
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
 - rhel-8-server-ose-rpms-embargoed


### PR DESCRIPTION
Following https://github.com/openshift/origin/pull/26131, the builds
failed complaining about a missing python3-cinderclient package. This
commit adds the containing repository.