### PR TITLE
Enable assemblies for 4.8

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -33,6 +33,9 @@ build_profiles:
       targets:
       - rhaos-{MAJOR}.{MINOR}-rhel-8-candidate
 
+assemblies:
+  enabled: true
+
 default_image_build_profile: unsigned
 default_rpm_build_profile: default
 


### PR DESCRIPTION
Allows 4.8 to begin using early assembly concepts.

Related:
- https://github.com/openshift/doozer/pull/408
- https://github.com/openshift/aos-cd-jobs/pull/2623