### PR TITLE
group.yaml: RHCOS 4.7 is using RHEL 8.3 (for now)

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -134,10 +134,10 @@ repos:
   rhel-8-baseos-rpms:
     conf:
       baseurl:
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/aarch64/baseos/os/
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/
-        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/baseos/os/
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.3/aarch64/baseos/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.3/ppc64le/baseos/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.3/s390x/baseos/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.3/x86_64/baseos/os/
       ci_alignment:
         profiles:
         - el8
@@ -154,11 +154,11 @@ repos:
   rhel-8-rt-rpms:
     conf:
       baseurl:
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/rt/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.3/x86_64/rt/os/
         # other arches don't exist, pointing at something that exists
-        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/rt/os/
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/rt/os/
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/rt/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.3/x86_64/rt/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.3/x86_64/rt/os/
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.3/x86_64/rt/os/
       ci_alignment:
         profiles:
         - el8
@@ -172,10 +172,10 @@ repos:
   rhel-8-appstream-rpms:
     conf:
       baseurl:
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/aarch64/appstream/os/
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/
-        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/appstream/os/
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.3/aarch64/appstream/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.3/ppc64le/appstream/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.3/s390x/appstream/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.3/x86_64/appstream/os/
       ci_alignment:
         profiles:
         - el8


### PR DESCRIPTION
Until some point after OCP 4.8 GA, we have pinned RHCOS 4.7 to use
RHEL 8.3 content.

This updates the RHEL 8 repos to pin explicitly to 8.3, which should
keep the driver-toolkit happy.

Any async packages that did not land in the `dist/rhel8/8.3` location
have been tagged into the RHAOS plashets, so we should not see any
downgrades or missing packages.

See: https://issues.redhat.com/browse/ART-2952
See: https://issues.redhat.com/browse/ART-2954