### PR TITLE
Pin the kernel for RHCOS 4.7 using RHEL 8.3

### DIFF
--- a/images/driver-toolkit.yml
+++ b/images/driver-toolkit.yml
@@ -10,15 +10,13 @@ content:
       match: "ARG RHEL_VERSION=''"
       replacement: "ARG RHEL_VERSION='8.3'"
 
-    # Uncomment the following sections to pin specific kernel versions
+    - action: replace
+      match: "ARG KERNEL_VERSION=''"
+      replacement: "ARG KERNEL_VERSION='4.18.0-240.22.1'"
 
-    # - action: replace
-    #   match: "ARG KERNEL_VERSION=''"
-    #   replacement: "ARG KERNEL_VERSION='1.2.3'"
-
-    # - action: replace
-    #   match: "ARG RT_KERNEL_VERSION=''"
-    #   replacement: "ARG RT_KERNEL_VERSION='1.2.3'"
+    - action: replace
+      match: "ARG RT_KERNEL_VERSION=''"
+      replacement: "ARG RT_KERNEL_VERSION='4.18.0-240.22.1.rt7.77'"
     git:
       branch:
         target: release-{MAJOR}.{MINOR}


### PR DESCRIPTION
Until some point after OCP 4.8 GA, we have pinned RHCOS 4.7 to use
RHEL 8.3 content.

In order to not break `driver-toolkit`, let's pin the kernel versions
that are expected to be used during this time.

We don't anticipate any changes to which kernel is used unless there
is a CVE or urgent problem that affects OCP which needs to be
backported.