### PR TITLE
4.8: Define Brew targets for hotfix builds

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -32,6 +32,8 @@ build_profiles:
     default:
       targets:
       - rhaos-{MAJOR}.{MINOR}-rhel-8-candidate
+      hotfix_targets:
+      - rhaos-{MAJOR}.{MINOR}-rhel-8-hotfix
 
 assemblies:
   enabled: true

--- a/rpms/openshift-ansible.yml
+++ b/rpms/openshift-ansible.yml
@@ -14,3 +14,6 @@ distgit:
   branch: rhaos-{MAJOR}.{MINOR}-rhel-7
 targets:
 - rhaos-{MAJOR}.{MINOR}-rhel-7-candidate  # this is needed for RHEL 7 worker node support
+hotfix_targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-7-hotfix  # this is needed for RHEL 7 worker node support
+

--- a/rpms/openshift-clients.yml
+++ b/rpms/openshift-clients.yml
@@ -13,3 +13,6 @@ distgit:
 targets:
 - rhaos-{MAJOR}.{MINOR}-rhel-7-candidate  # this is needed for RHEL 7 worker node support
 - rhaos-{MAJOR}.{MINOR}-rhel-8-candidate
+hotfix_targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-7-hotfix  # this is needed for RHEL 7 worker node support
+- rhaos-{MAJOR}.{MINOR}-rhel-8-hotfix

--- a/rpms/openshift.yml
+++ b/rpms/openshift.yml
@@ -19,3 +19,6 @@ distgit:
 targets:
 - rhaos-{MAJOR}.{MINOR}-rhel-7-candidate  # this is needed for RHEL 7 worker node support
 - rhaos-{MAJOR}.{MINOR}-rhel-8-candidate
+hotfix_targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-7-hotfix  # this is needed for RHEL 7 worker node support
+- rhaos-{MAJOR}.{MINOR}-rhel-8-hotfix


### PR DESCRIPTION
Some rpms use non-default Brew targets. Needs to define them explicitly.
Merge this before https://github.com/openshift/doozer/pull/410.