### PR TITLE
Add image ose-openshift-proxy-pull-test

### DIFF
--- a/images/openshift-proxy-pull-test.yml
+++ b/images/openshift-proxy-pull-test.yml
@@ -1,0 +1,17 @@
+container_yaml:
+  go:
+    modules:
+    - module: github.com/openshift/machine-config-operator
+content:
+  source:
+    dockerfile: Dockerfile.proxy
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/machine-config-operator.git
+for_payload: false
+from:
+  member: openshift-enterprise-base
+name: openshift/ose-openshift-proxy-pull-test
+owners:
+- qiwan@redhat.com


### PR DESCRIPTION
Add this image into the ocp-build-data(https://github.com/openshift/ocp-build-data)
repository. So product MCO(https://github.com/openshift/machine-config-operator) can
pull the image through a proxy that the customer configured to validate the proxy.

Ticket for the image build request: https://issues.redhat.com/browse/ART-2961

Signed-off-by: Qi Wang <qiwan@redhat.com>