### PR TITLE
Revert "align with upstream change"

### DIFF
--- a/images/logging-kibana6.yml
+++ b/images/logging-kibana6.yml
@@ -1,6 +1,6 @@
 content:
   source:
-    dockerfile: Dockerfile
+    dockerfile: Dockerfile.rhel8
     git:
       branch:
         target: release-{MAJOR}.{MINOR}


### PR DESCRIPTION
This reverts commit 6e0d7ba88d4c0f7619828be88bee8fd355746a0b.

There's no symlink in `release-4.6` branch. We still need to build from Dockerfile.rhel8 except the developers request that.