### PR TITLE
Update ubi8 base image

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -69,12 +69,12 @@ rhel-7-golang:
 rhel8:
   # the most recent release at present. since we yum update this, maybe it does not need to float.
   # but it is important that we not build from unreleased builds.
-  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi8:8.4-199
+  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi8:8.4-206
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-openshift-{MAJOR}.{MINOR}.art
   mirror: true
 
 nodejs:
   # the most recent release with precise nodejs 14 version we need.
-  image: ubi8/nodejs-14:1-31
+  image: ubi8/nodejs-14:1-35
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-openshift-nodejs-base-{MAJOR}.{MINOR}.art
   mirror: true


### PR DESCRIPTION
While this image is updated in base-rhel8, that results in bigger images 
than when starting with a current base.

It would be preferable to let this float (e.g. `registry.redhat.io/ubi8:8.4`) 
but it seems that was tried previously and there were issues?

