### PR TITLE
Stop building ppc64le for 3.11

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -35,7 +35,6 @@ default_rpm_build_profile: default
 
 arches:
 - x86_64
-- ppc64le
 branch: rhaos-{MAJOR}.{MINOR}-rhel-7
 default_image_build_method: imagebuilder
 name: openshift-{MAJOR}.{MINOR}


### PR DESCRIPTION
As per the document
https://access.redhat.com/support/policy/updates/openshift_noncurrent,
POWER for 3.X is EOL after June 2021. This commit removes the ppc64le
architecture from the build targets of 3.11.