### PR TITLE
OpenShift 4.9: Update cloud team PR prefixes

### DIFF
--- a/images/ose-azure-machine-controllers.yml
+++ b/images/ose-azure-machine-controllers.yml
@@ -11,6 +11,9 @@ content:
       branch:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-api-provider-azure.git
+    ci_alignment:
+      streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: openshift: "    
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms

--- a/images/ose-machine-api-operator.yml
+++ b/images/ose-machine-api-operator.yml
@@ -9,9 +9,6 @@ content:
       branch:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/machine-api-operator.git
-    ci_alignment:
-      streams_prs:
-        commit_prefix: "UPSTREAM: <carry>: "
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms


### PR DESCRIPTION
> I asked about getting these fixed yesterday in slack https://coreos.slack.com/archives/CB95J6R4N/p1623754058362900 but had intended for the Azure image to be fixed up as this is the one that causes issues. We are adding more repos in the future which will need this prefix (anything forked as cloud-proivder-...), so assuming I'm following the correct process here I should be able to add these in the future independently?

This is the same as #950 but for 4.9