### PR TITLE
Make CCCMO WIP

### DIFF
--- a/images/ose-cluster-cloud-controller-manager-operator.yml
+++ b/images/ose-cluster-cloud-controller-manager-operator.yml
@@ -1,3 +1,4 @@
+mode: wip
 container_yaml:
   go:
     modules:


### PR DESCRIPTION
This reverts commit 61bd5aac9ef56e920b79c53ac47d49e09aad1696.

CCCMO has a couple of dependent images still in the process of being added to the payload, this means the image reference is breaking the nightly builds right now