### PR TITLE
Switch Ceph to ELS repos

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -81,12 +81,12 @@ repos:
   rhel-7-server-rhceph-3-tools-rpms:
     conf:
       baseurl:
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel/power-le/7/7Server/ppc64le/rhceph-tools/3/os/
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel/server/7/7Server/x86_64/rhceph-tools/3/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/els/rhel/power-le/7/7Server/ppc64le/rhceph-tools/3/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/els/rhel/server/7/7Server/x86_64/rhceph-tools/3/os/
     content_set:
-      default: rhel-7-server-rhceph-3-tools-rpms
+      default: rhel-7-server-rhceph-3-tools-els-rpms
       optional: true
-      ppc64le: rhel-7-server-rhceph-3-for-power-le-tools-rpms
+      ppc64le: rhel-7-server-rhceph-3-for-power-le-tools-els-rpms
   rhel-fast-datapath-rpms:
     conf:
       baseurl:


### PR DESCRIPTION
Ceph 3 ended regular support earlier this year, updates are only going
to ELS now:

https://access.redhat.com/support/policy/updates/ceph-storage
