### PR TITLE
[ART-3100] Do not sweep Test Infrastructure bugs

### DIFF
--- a/bugzilla.yml
+++ b/bugzilla.yml
@@ -53,6 +53,9 @@ filters:
     - field: "component"
       operator: "notequals"
       value: "Poison Pill Operator"
+    - field: "component"
+      operator: "notequals"
+      value: "Test Infrastructure"
   security:
     - field: "component"
       operator: "notequals"


### PR DESCRIPTION
Test Infrastructure bugs are not user facing, and do not need to be swept into advisories.

...unless there is a good reason we're not doing so already. Up for discussion.