### PR TITLE
Change location of manifests directory

### DIFF
--- a/images/local-storage-operator.yml
+++ b/images/local-storage-operator.yml
@@ -25,5 +25,5 @@ owners:
 update-csv:
   bundle-dir: '{MAJOR}.{MINOR}/'
   channel: stable
-  manifests-dir: manifests
+  manifests-dir: config/manifests
   registry: image-registry.openshift-image-registry.svc:5000


### PR DESCRIPTION
In LSO we changed location of manifests directory - https://github.com/openshift/local-storage-operator/tree/master/config/manifests

