### PR TITLE
Ignore poison pill from security bugs too

### DIFF
--- a/bugzilla.yml
+++ b/bugzilla.yml
@@ -87,3 +87,6 @@ filters:
     - field: "component"
       operator: "notequals"
       value: "Node Maintenance Operator"
+    - field: "component"
+      operator: "notequals"
+      value: "Poison Pill Operator"


### PR DESCRIPTION
This commit added the operator component to ignore https://github.com/openshift/ocp-build-data/commit/2007fa5365a136fa454350f0c393d22b31ea7007 to default list. Add component to security filter too.


