### PR TITLE
[openshift-4.8] driver-toolkit: pin kernel for 4.8

### DIFF
--- a/images/driver-toolkit.yml
+++ b/images/driver-toolkit.yml
@@ -12,13 +12,13 @@ content:
 
     # Uncomment the following sections to pin specific kernel versions
 
-    # - action: replace
-    #   match: "ARG KERNEL_VERSION=''"
-    #   replacement: "ARG KERNEL_VERSION='1.2.3'"
+    - action: replace
+      match: "ARG KERNEL_VERSION=''"
+      replacement: "ARG KERNEL_VERSION='4.18.0-305.10.2.el8_4'"
 
-    # - action: replace
-    #   match: "ARG RT_KERNEL_VERSION=''"
-    #   replacement: "ARG RT_KERNEL_VERSION='1.2.3'"
+    - action: replace
+      match: "ARG RT_KERNEL_VERSION=''"
+      replacement: "ARG RT_KERNEL_VERSION='4.18.0-305.10.2.rt7.83.el8_4'"
     git:
       branch:
         target: release-{MAJOR}.{MINOR}


### PR DESCRIPTION
We are in an uncomfortable position of having to pin the kernel trying
to get builds out in time to address CVE-2021-33909, so pin the kernel
just to be safe.