### PR TITLE
[openshift-4.7] driver-toolkit: pin kernel for 4.7

### DIFF
--- a/images/driver-toolkit.yml
+++ b/images/driver-toolkit.yml
@@ -10,6 +10,8 @@ content:
       match: "ARG RHEL_VERSION=''"
       replacement: "ARG RHEL_VERSION='8.3'"
 
+    # Uncomment the following sections to pin specific kernel versions
+
     - action: replace
       match: "ARG KERNEL_VERSION=''"
       replacement: "ARG KERNEL_VERSION='4.18.0-240.23.2.el8_3'"


### PR DESCRIPTION
We are in an uncomfortable position of having to pin the kernel trying
to get builds out in time to address CVE-2021-33909, so pin the kernel
just to be safe.