### PR TITLE
[openshift-4.7] Update base images

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -78,12 +78,12 @@ rhel-7-golang:
 rhel8:
   # the most recent release at present. since we yum update this, maybe it does not need to float.
   # but it is important that we not build from unreleased builds.
-  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi8:8.3-297
+  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi8:8.4-206
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-openshift-{MAJOR}.{MINOR}.art
   mirror: true
 
 nodejs:
   # the most recent release with precise nodejs 14 version we need.
-  image: ubi8/nodejs-14:1-21.1615199885
+  image: ubi8/nodejs-14:1-35
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-openshift-nodejs-base-{MAJOR}.{MINOR}.art
   mirror: true


### PR DESCRIPTION
Because RHEL 8.3 was not EUS, the yum updates in base-rhel8 and
base-nodejs have essentially been updating these to 8.4 since its
release.
