### PR TITLE
Fix location of efs manifests

### DIFF
--- a/images/ose-aws-efs-csi-driver-operator.yml
+++ b/images/ose-aws-efs-csi-driver-operator.yml
@@ -27,5 +27,5 @@ owners:
 - aos-storage-staff@redhat.com
 update-csv:
   bundle-dir: '{MAJOR}.{MINOR}/'
-  manifests-dir: manifests/
+  manifests-dir: config/manifests
   registry: image-registry.openshift-image-registry.svc:5000


### PR DESCRIPTION
We changed location of manifests - https://github.com/openshift/aws-efs-csi-driver-operator/commit/f7d484b6e5cdf191b58fd8261d1c5663b7c0ebbf

