### PR TITLE
Removes BZ section from 4.8 template

### DIFF
--- a/erratatool.yml
+++ b/erratatool.yml
@@ -96,10 +96,6 @@ boilerplates:
 
       https://docs.openshift.com/container-platform/4.8/release_notes/ocp-4-8-release-notes.html
 
-      This update fixes the following bugs among others:
-
-      [[BZs]]
-
       You may download the oc tool and use it to inspect release image metadata as follows:
 
           (For x86_64 architecture)


### PR DESCRIPTION
@stevsmit confirmed with @sferich888 that we were ok to always put BZ entries in the Release Notes themselves, so this PR removes the related section. 

Some background on why we proposed this change:
The previous situation was that we would add BZ doc text to the advisory text if it fit, but if it exceeded the Errata character limit, it would go into the Rel Notes. By always including it in the Rel Notes, we make for a more consistent customer experience instead of having them find this in one of two locations for seemingly arbitrary reasons. 
It also ensures that doc text gets documentation peer review, and allows us to make updates after publication if needed (which we cannot do with Errata).

I think we are ok to go ahead with this, but I will bring it up at the next z-stream call so all parties have a chance to weigh in.