### PR TITLE
Enable module_hotfixes for ose rhel-8 repos

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -89,9 +89,12 @@ repos:
     reposync:
       enabled: false
 
-  # Included to trigger reposync of rhel-8 rpms
   rhel-8-server-ose-rpms-embargoed:
     conf:
+      extra_options:
+        # Required to enable RPMs with higher NVRs to show up as installable options in the presence of modules from another repo.
+        # i.e. modules mask traditional rpms unless this flag is provided.
+        module_hotfixes: 1
       baseurl:
         aarch64: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el8/{runtime_assembly}/building-embargoed/aarch64/os
         ppc64le: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el8/{runtime_assembly}/building-embargoed/ppc64le/os
@@ -109,6 +112,10 @@ repos:
 
   rhel-8-server-ose-rpms:
     conf:
+      extra_options:
+        # Required to enable RPMs with higher NVRs to show up as installable options in the presence of modules from another repo.
+        # i.e. modules mask traditional rpms unless this flag is provided.
+        module_hotfixes: 1
       baseurl:
         aarch64: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el8/building/aarch64/os
         ppc64le: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el8/building/ppc64le/os


### PR DESCRIPTION
Observed this message from gen-payload:
```yaml
assembly_issues:
  openshift-enterprise-builder:
  - code: OUTDATED_RPMS_IN_STREAM_BUILD
    msg: Found outdated RPM (runc-1.0.0-73.rc93.module+el8.4.0+11311+9da8acfb) installed
      in openshift-enterprise-builder-container-v4.9.0-202107292001.p0.git.94e422c.assembly.stream
      when runc-1.0.1-2.rhaos4.9.git4144b63.el8 was available
```

After digging, I found that `runc-1.0.1-2.rhaos4.9.git4144b63.el8` was in the plashet when `openshift-enterprise-builder-container-v4.9.0-202107292001.p0.git.94e422c.assembly.stream` was built. However, the RPM was not found because yum was finding `runc-1.0.0-73.rc93.module+el8.4.0+11311+9da8acfb` in the rhel-8 appstream repo.

Despite the rhaos4.9 RPM having a greater NVR, the fact that the appstream version was a module seemed to entire hide it from yum. I reproduced this using UBI8 and the same repos. Whenever appstream was enabled, the rhaos runc was completely ignored. 

@yselkowitz informed me that `module_hotfixes = 1` in the repo definition could fix this - and it did in my UBI8 environment. Adding it here officially so I can rebuild the builder image.