### PR TITLE
[openshift-4.7] Update driver-toolkit.yml kernel versions for 8.4 kernel

### DIFF
--- a/images/driver-toolkit.yml
+++ b/images/driver-toolkit.yml
@@ -8,15 +8,15 @@ content:
     modifications:
     - action: replace
       match: "ARG RHEL_VERSION=''"
-      replacement: "ARG RHEL_VERSION='8.3'"
+      replacement: "ARG RHEL_VERSION='8.4'"
 
     - action: replace
       match: "ARG KERNEL_VERSION=''"
-      replacement: "ARG KERNEL_VERSION='4.18.0-240.23.2.el8_3'"
+      replacement: "ARG KERNEL_VERSION='4.18.0-305.10.2.el8_4'"
 
     - action: replace
       match: "ARG RT_KERNEL_VERSION=''"
-      replacement: "ARG RT_KERNEL_VERSION='4.18.0-240.23.2.rt7.79.el8_3'"
+      replacement: "ARG RT_KERNEL_VERSION='4.18.0-305.10.2.rt7.83.el8_4'"
     git:
       branch:
         target: release-{MAJOR}.{MINOR}


### PR DESCRIPTION
Since 4.8 is GA, the kernel in RHCOS in 4.7.z has moved to the kernel from RHEL 8.4. 

Signed-off-by: David Gray <dagray@redhat.com>