### PR TITLE
driver-toolkit: revert RHEL 8.3 pins / repo

### DIFF
--- a/images/driver-toolkit.yml
+++ b/images/driver-toolkit.yml
@@ -10,13 +10,15 @@ content:
       match: "ARG RHEL_VERSION=''"
       replacement: "ARG RHEL_VERSION='8.3'"
 
-    - action: replace
-      match: "ARG KERNEL_VERSION=''"
-      replacement: "ARG KERNEL_VERSION='4.18.0-240.23.2.el8_3'"
+    # Uncomment the following sections to pin specific kernel versions
 
-    - action: replace
-      match: "ARG RT_KERNEL_VERSION=''"
-      replacement: "ARG RT_KERNEL_VERSION='4.18.0-240.23.2.rt7.79.el8_3'"
+    # - action: replace
+    #   match: "ARG KERNEL_VERSION=''"
+    #   replacement: "ARG KERNEL_VERSION='1.2.3'"
+
+    # - action: replace
+    #   match: "ARG RT_KERNEL_VERSION=''"
+    #   replacement: "ARG RT_KERNEL_VERSION='1.2.3'"
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
@@ -25,7 +27,6 @@ enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-rt-rpms
 - rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms-embargoed
 for_payload: true
 from:
   member: openshift-enterprise-base


### PR DESCRIPTION
per [conversation](https://coreos.slack.com/archives/CB95J6R4N/p1628614813142500?thread_ts=1628543497.130400&cid=CB95J6R4N) we will let 4.7 consume latest RHEL 8.4 content.