### PR TITLE
Fix nodejs base image build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ FROM nodejs
 
 USER root
 RUN echo 'skip_missing_names_on_install=0' >> /etc/yum.conf \
- && echo 'exclude=nodejs nodejs-docs npm' >> /etc/yum.conf \
+ && echo 'exclude=nodejs nodejs-docs nodejs-full-i18n npm' >> /etc/yum.conf \
  && yum update -y  \
  && yum clean all
 USER 1001


### PR DESCRIPTION
```
Error:
Problem: package nodejs-full-i18n-1:14.17.3-2.module+el8.4.0+11738+3bd42762.x86_64
requires nodejs(x86-64) = 1:14.17.3-2.module+el8.4.0+11738+3bd42762,
but none of the providers can be installed
```
from e.g.
http://download.eng.bos.redhat.com/brewroot/work/tasks/3742/38883742/x86_64.log.

Also disallow changing the version of nodejs-full-i18n.