### PR TITLE
Update RHEL version in driver-toolkit

### DIFF
--- a/images/driver-toolkit.yml
+++ b/images/driver-toolkit.yml
@@ -8,7 +8,7 @@ content:
     modifications:
     - action: replace
       match: "ARG RHEL_VERSION=''"
-      replacement: "ARG RHEL_VERSION='8.3'"
+      replacement: "ARG RHEL_VERSION='8.4'"
 
     # Uncomment the following sections to pin specific kernel versions
 


### PR DESCRIPTION
PR #1032 fixed the kernel version, but we forgot to also update the RHEL version to 8.4(which RHCOS is now based on in 4.7).

Signed-off-by: David Gray <dagray@redhat.com>