### PR TITLE
Revert "Pin the missing cli image to 4.7.26"

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -14,12 +14,7 @@ releases:
           extras: 80549
           metadata: 80550
       members:
-        images:
-        - distgit_key: openshift-enterprise-cli
-          why: "The basis event doesn't include this build."
-          metadata:
-            is:
-              nvr: openshift-enterprise-cli-container-v4.7.0-202108160002.p0.git.d1ffb3c.assembly.stream
+        images: []
         rpms: []
       rhcos:
         machine-os-content:


### PR DESCRIPTION
Reverts openshift/ocp-build-data#1042

Not needed. It was caused by a different issue, see https://issues.redhat.com/browse/ART-3277