### PR TITLE
[4.9] Work around pthread creation error

### DIFF
--- a/images/openshift-enterprise-hyperkube.yml
+++ b/images/openshift-enterprise-hyperkube.yml
@@ -12,7 +12,7 @@ content:
     modifications:
     - action: replace
       match: "make WHAT="
-      replacement: "make GOFLAGS='-mod=vendor -p=8' WHAT="
+      replacement: "make GOFLAGS='-mod=vendor -p=4' WHAT="
 distgit:
   namespace: containers
 enabled_repos:


### PR DESCRIPTION
On aarch64, this image often fails to build with an error like:
```
runtime/cgo: pthread_create failed: Resource temporarily unavailable
```

See e.g. http://download.eng.bos.redhat.com/brewroot/work/tasks/332/39520332/aarch64.log

Parallel to https://github.com/openshift/ocp-build-data/pull/1065

/cc @yselkowitz 