### PR TITLE
[openshift-4.10] Set treshhold_hours to 1

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -304,7 +304,7 @@ image_build_log_scanner:
   - orchestrator.log
 scan_freshness:
   release_regex: '(?x) ^ (\d\d\d\d) (\d\d) (\d\d) (\d\d)'
-  threshold_hours: 6
+  threshold_hours: 1
 csv_namespace: openshift
 # whether and how to check if all buildroots have consistent versions of golang compilers (rpm build only)
 # "x.y" (default): only major and minor version; "exact": the z-version must be the same; "no": do not check


### PR DESCRIPTION
Setting scanning freshness treshhold hours to 1. It seems unnecessary to
wait for 6 hours for a failed build, especially since we do not create
nightlies anymore if siblings are based off a different commit.

For context, we have had this set to 1 hour for 4.8, and I have not
noticed an issue with that.

```
⫸  yq -r '@text "\(.vars.MAJOR).\(.vars.MINOR) scan_freshness.treshhold_hours: \(.scan_freshness.threshold_hours)"' */group.yml
3.11 scan_freshness.treshhold_hours: null
4.5 scan_freshness.treshhold_hours: 6
4.6 scan_freshness.treshhold_hours: 6
4.7 scan_freshness.treshhold_hours: 6
4.8 scan_freshness.treshhold_hours: 1
4.9 scan_freshness.treshhold_hours: 6
4.10 scan_freshness.treshhold_hours: 6
```