### PR TITLE
4.7.30: Permit CONFLICTING_INHERITED_DEPENDENCY

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -37,6 +37,9 @@ releases:
             s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:32d6175a9cbd4d437f87923e1a7695cc2b827e4380c5adbb1a82a12c468fc7b6
             x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cb90a29562fd3802ff3a50a5290da9a07358c7a8355d961b24cafb38bc860402
       type: standard
+      permits:
+      - code: CONFLICTING_INHERITED_DEPENDENCY
+        component: '*'
   4.7.29:
     assembly:
       basis:


### PR DESCRIPTION
Permits the following issues:

```yaml
assembly_issues:
  cluster-node-tuning-operator:
  - code: CONFLICTING_INHERITED_DEPENDENCY
    msg: Expected image to contain assembly override dependencies NVR kernel-4.18.0-305.19.1.el8_4
      but found kernel-4.18.0-305.12.1.el8_4 installed
    permitted: false
  ironic-rhcos-downloader:
  - code: CONFLICTING_INHERITED_DEPENDENCY
    msg: Expected image to contain assembly override dependencies NVR kernel-4.18.0-305.19.1.el8_4
      but found kernel-4.18.0-305.12.1.el8_4 installed
    permitted: false
  openshift-enterprise-operator-sdk:
  - code: CONFLICTING_INHERITED_DEPENDENCY
    msg: Expected image to contain assembly override dependencies NVR kernel-4.18.0-305.19.1.el8_4
      but found kernel-4.18.0-305.12.1.el8_4 installed
    permitted: false
  openshift-enterprise-tests:
  - code: CONFLICTING_INHERITED_DEPENDENCY
    msg: Expected image to contain assembly override dependencies NVR kernel-4.18.0-305.19.1.el8_4
      but found kernel-4.18.0-305.12.1.el8_4 installed
    permitted: false
  ose-jenkins-agent-nodejs-10:
  - code: CONFLICTING_INHERITED_DEPENDENCY
    msg: Expected image to contain assembly override dependencies NVR kernel-4.18.0-305.19.1.el8_4
      but found kernel-4.18.0-305.12.1.el8_4 installed
    permitted: false
  ose-jenkins-agent-nodejs-12:
  - code: CONFLICTING_INHERITED_DEPENDENCY
    msg: Expected image to contain assembly override dependencies NVR kernel-4.18.0-305.19.1.el8_4
      but found kernel-4.18.0-305.12.1.el8_4 installed
    permitted: false
  ose-network-tools:
  - code: CONFLICTING_INHERITED_DEPENDENCY
    msg: Expected image to contain assembly override dependencies NVR kernel-4.18.0-305.19.1.el8_4
      but found kernel-4.18.0-305.12.1.el8_4 installed
    permitted: false
  ose-tools:
  - code: CONFLICTING_INHERITED_DEPENDENCY
    msg: Expected image to contain assembly override dependencies NVR kernel-4.18.0-305.19.1.el8_4
      but found kernel-4.18.0-305.12.1.el8_4 installed
    permitted: false
missing_image_builds: []
```