### PR TITLE
Update commit prefixes for cloud provider forks

### DIFF
--- a/images/ose-aws-cloud-controller-manager.yml
+++ b/images/ose-aws-cloud-controller-manager.yml
@@ -14,6 +14,7 @@ content:
       url: git@github.com:openshift-priv/cloud-provider-aws.git
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
 enabled_repos:

--- a/images/ose-ibm-cloud-controller-manager.yml
+++ b/images/ose-ibm-cloud-controller-manager.yml
@@ -11,6 +11,7 @@ content:
       url: git@github.com:openshift-priv/cloud-provider-ibm.git
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
 enabled_repos:

--- a/images/ose-ibmcloud-machine-controllers.yml
+++ b/images/ose-ibmcloud-machine-controllers.yml
@@ -10,6 +10,7 @@ content:
       url: git@github.com:openshift-priv/cluster-api-provider-ibmcloud.git
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
 enabled_repos:


### PR DESCRIPTION
These repositories are forks from upstreams which have git history checks. We use this prefix to identify downstream commits. This should fix the dockerfile update PRs to include the correct git history.