### PR TITLE
[openshift-4.10] Point rhcos builds to 4.10

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -55,7 +55,7 @@ urls:
     x86_64: https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.10
     s390x: https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.10-s390x
     ppc64le: https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.10-ppc64le
-    aarch64: https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.10-aarch64
+    aarch64: https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.9-aarch64
 dist_git_ignore:
   - gating.yaml
 

--- a/group.yml
+++ b/group.yml
@@ -52,10 +52,10 @@ urls:
   cgit: http://pkgs.devel.redhat.com/cgit
   # temporarily point at 4.9 until 4.10 RHCOS gets rolling
   rhcos_release_base:
-    x86_64: https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.9
-    s390x: https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.9-s390x
-    ppc64le: https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.9-ppc64le
-    aarch64: https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.9-aarch64
+    x86_64: https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.10
+    s390x: https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.10-s390x
+    ppc64le: https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.10-ppc64le
+    aarch64: https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.10-aarch64
 dist_git_ignore:
   - gating.yaml
 


### PR DESCRIPTION
As https://issues.redhat.com/browse/GRPA-4180 is marked as Done, point 4.10 to use 4.10 rhcos.

Opting for an explicit `4.10` rather than `{MAJOR}.{MINOR}`, as that will maybe help with the next branch cut.