### PR TITLE
[4.9] erratatool: Add aarch64 to cdn_repos

### DIFF
--- a/erratatool.yml
+++ b/erratatool.yml
@@ -15,6 +15,7 @@ cdn_repos:
 - rhocp-{MAJOR}_DOT_{MINOR}-for-rhel-8-x86_64-rpms
 - rhocp-{MAJOR}_DOT_{MINOR}-for-rhel-8-ppc64le-rpms
 - rhocp-{MAJOR}_DOT_{MINOR}-for-rhel-8-s390x-rpms
+- rhocp-{MAJOR}_DOT_{MINOR}-for-rhel-8-aarch64-rpms
 
 synopsis:
   rpm: "OpenShift Container Platform 4.9 bug fix and enhancement update"


### PR DESCRIPTION
4.9 is to be shipped on ARM like the other architectures, but not documented due to its status as Developer Preview on ARM.
