### PR TITLE
[ART-3341] Add ironic-agent to the payload

### DIFF
--- a/images/ironic-agent.yml
+++ b/images/ironic-agent.yml
@@ -11,7 +11,7 @@ content:
       branch:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ironic-agent-image.git
-for_payload: false
+for_payload: true
 from:
   member: openshift-base-rhel8
 name: openshift/ose-ironic-agent


### PR DESCRIPTION
cluster-baremetal-operator just added a reference to ironic-agent:

https://github.com/openshift/cluster-baremetal-operator/pull/202

Therefore it needs to be in the payload, and it not being so is now
causing the payload generation to fail.
