### PR TITLE
[openshift-4.9] Temporarily disable special-resource-operator

### DIFF
--- a/images/special-resource-operator.yml
+++ b/images/special-resource-operator.yml
@@ -1,3 +1,5 @@
+# There is a rebase error, which blocks image builds. Disabling for now.
+mode: disabled
 container_yaml:
   go:
     modules:


### PR DESCRIPTION
Due to an error in rebasing folling a name change, image builds are
blocked. Temporarily disabling special-resource-operator.