### PR TITLE
[openshift-4.9] Reenable metallb-operator

### DIFF
--- a/images/ose-metallb-operator.yml
+++ b/images/ose-metallb-operator.yml
@@ -1,5 +1,3 @@
-# [lmeyer] currently blocking rebases due to image-references inconsistency
-mode: disabled
 content:
   source:
     git:

--- a/images/ose-metallb.yml
+++ b/images/ose-metallb.yml
@@ -1,5 +1,3 @@
-# [lmeyer] currently blocking rebases due to image-references inconsistency
-mode: disabled
 container_yaml:
   go:
     modules:


### PR DESCRIPTION
...as https://github.com/openshift/metallb-operator/pull/33 got merged.
edit: https://github.com/openshift/ocp-build-data/pull/1151 fix is in