### PR TITLE
[openshift-4.7][ART-3423] Use RHEL 8.4 EUS content

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -141,58 +141,58 @@ repos:
   rhel-8-baseos-rpms:
     conf:
       baseurl:
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/aarch64/baseos/os/
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/
-        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/baseos/os/
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.4/aarch64/baseos/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.4/ppc64le/baseos/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.4/s390x/baseos/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.4/x86_64/baseos/os/
       ci_alignment:
         profiles:
         - el8
         localdev:
           enabled: true
     content_set:
-      default: rhel-8-for-x86_64-baseos-rpms
-      aarch64: rhel-8-for-aarch64-baseos-rpms
-      ppc64le: rhel-8-for-ppc64le-baseos-rpms
-      s390x: rhel-8-for-s390x-baseos-rpms
+      default: rhel-8-for-x86_64-baseos-eus-rpms__8_DOT_4
+      aarch64: rhel-8-for-aarch64-baseos-eus-rpms__8_DOT_4
+      ppc64le: rhel-8-for-ppc64le-baseos-eus-rpms__8_DOT_4
+      s390x: rhel-8-for-s390x-baseos-eus-rpms__8_DOT_4
     reposync:
       enabled: false
 
   rhel-8-rt-rpms:
     conf:
       baseurl:
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/rt/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/tus/rhel8/8.4/x86_64/rt/os/
         # other arches don't exist, pointing at something that exists
-        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/rt/os/
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/rt/os/
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/rt/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/tus/rhel8/8.4/x86_64/rt/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/tus/rhel8/8.4/x86_64/rt/os/
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/tus/rhel8/8.4/x86_64/rt/os/
       ci_alignment:
         profiles:
         - el8
         localdev:
           enabled: true
     content_set:
-      default: rhel-8-for-x86_64-rt-rpms
+      default: rhel-8-for-x86_64-rt-tus-rpms__8_DOT_4
       # don't have content set for other arches
       optional: true
 
   rhel-8-appstream-rpms:
     conf:
       baseurl:
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/aarch64/appstream/os/
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/
-        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/appstream/os/
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.4/aarch64/appstream/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.4/ppc64le/appstream/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.4/s390x/appstream/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.4/x86_64/appstream/os/
       ci_alignment:
         profiles:
         - el8
         localdev:
           enabled: true
     content_set:
-      default: rhel-8-for-x86_64-appstream-rpms
-      aarch64: rhel-8-for-aarch64-appstream-rpms
-      ppc64le: rhel-8-for-ppc64le-appstream-rpms
-      s390x: rhel-8-for-s390x-appstream-rpms
+      default: rhel-8-for-x86_64-appstream-eus-rpms__8_DOT_4
+      aarch64: rhel-8-for-aarch64-appstream-eus-rpms__8_DOT_4
+      ppc64le: rhel-8-for-ppc64le-appstream-eus-rpms__8_DOT_4
+      s390x: rhel-8-for-s390x-appstream-eus-rpms__8_DOT_4
     reposync:
       enabled: false
 

--- a/streams.yml
+++ b/streams.yml
@@ -78,7 +78,7 @@ rhel-7-golang:
 rhel8:
   # the most recent release at present. since we yum update this, maybe it does not need to float.
   # but it is important that we not build from unreleased builds.
-  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi8:8.4-211
+  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi8:8.4-213
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-openshift-{MAJOR}.{MINOR}.art
   mirror: true
 


### PR DESCRIPTION
Backport of #1126 to 4.7 (does not cherry-pick due to addition of CRB in 4.8).