### PR TITLE
Enable Ironic containers on aarch64

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -265,9 +265,9 @@ repos:
       baseurl:
         ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/ppc64le/openstack/16/os/
         x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/x86_64/openstack/16/os/
-        # XXX: aarch64 and s390x don't exist, point it at something that exists so yum doesn't choke
-        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/x86_64/openstack/16/os/
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/x86_64/openstack/16/os/
+        # XXX: aarch64 and s390x RHOS don't exist, use puddles for now in order to build Ironic
+        s390x: http://download-node-02.eng.bos.redhat.com/rcm-guest/puddles/Multi-Arch/OpenStack/16.2/latest/OpenStack/s390x/os/
+        aarch64: http://download-node-02.eng.bos.redhat.com/rcm-guest/puddles/Multi-Arch/OpenStack/16.2/latest/OpenStack/aarch64/os/
       ci_alignment:
         profiles:
         - el8
@@ -278,6 +278,8 @@ repos:
       ppc64le: openstack-16-for-rhel-8-ppc64le-rpms
       # don't have content set for aarch64 or s390x
       optional: true
+    reposync:
+      enabled: true
 
 default_image_build_method: imagebuilder
 image_build_log_scanner:

--- a/images/ironic-agent.yml
+++ b/images/ironic-agent.yml
@@ -1,5 +1,6 @@
 arches:
 - x86_64
+- aarch64
 container_yaml:
   go:
     modules:

--- a/images/ironic-hardware-inventory-recorder-image.yml
+++ b/images/ironic-hardware-inventory-recorder-image.yml
@@ -1,6 +1,6 @@
 arches:
 - x86_64
-- ppc64le
+- aarch64
 container_yaml:
   go:
     modules:

--- a/images/ironic-ipa-downloader.yml
+++ b/images/ironic-ipa-downloader.yml
@@ -1,6 +1,5 @@
 arches:
 - x86_64
-- ppc64le
 content:
   source:
     dockerfile: Dockerfile.ocp

--- a/images/ironic-rhcos-downloader.yml
+++ b/images/ironic-rhcos-downloader.yml
@@ -1,6 +1,6 @@
 arches:
 - x86_64
-- ppc64le
+- aarch64
 content:
   source:
     dockerfile: Dockerfile.ocp

--- a/images/ironic-static-ip-manager.yml
+++ b/images/ironic-static-ip-manager.yml
@@ -1,6 +1,6 @@
 arches:
 - x86_64
-- ppc64le
+- aarch64
 content:
   source:
     dockerfile: Dockerfile.ocp

--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -1,6 +1,6 @@
 arches:
 - x86_64
-- ppc64le
+- aarch64
 content:
   source:
     dockerfile: Dockerfile.ocp


### PR DESCRIPTION
- Use puddles for RHOS content on s390x and aarch64
- Enable Ironic images on aarch64, disable ppc64le

Except for ironic-ipa-downloader, which is being deprecated in 4.10.  Bare Metal IPI support never happened for Power, so it is disabled too.