### PR TITLE
4.10: Allow MISMATCHED_SIBLINGS

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -1,1 +1,8 @@
-releases: {}
+releases:
+  stream:
+    assembly:
+      type: stream
+      permits:
+      # why: "Always build shippable" does not yet apply to 4.10
+      - code: MISMATCHED_SIBLINGS
+        component: '*'


### PR DESCRIPTION
Currently, no nightlies are being produced because mismatched siblings
are detected. One cause is openshift-installer failing to build on for
ppc64le, which possibly is solved by upgrading golang to 1.17.
Permitting this class of inconsistencies for now.