### PR TITLE
4.10 disable *metallb*

### DIFF
--- a/images/ose-metallb-operator.yml
+++ b/images/ose-metallb-operator.yml
@@ -1,3 +1,5 @@
+mode: disabled
+# https://issues.redhat.com/browse/ART-3437
 content:
   source:
     git:

--- a/images/ose-metallb.yml
+++ b/images/ose-metallb.yml
@@ -1,3 +1,5 @@
+mode: disabled
+# https://issues.redhat.com/browse/ART-3437
 container_yaml:
   go:
     modules:


### PR DESCRIPTION
Until https://issues.redhat.com/browse/ART-3437 is resolved, the early
operator index job will fail. Disabling for now.