### PR TITLE
4.10 Allow CONFLICTING_GROUP_RPM_INSTALLED and OUTDATED_RPMS_IN_STREA…

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -6,3 +6,7 @@ releases:
       # why: "Always build shippable" does not yet apply to 4.10
       - code: MISMATCHED_SIBLINGS
         component: '*'
+      - code: OUTDATED_RPMS_IN_STREAM_BUILD
+        component: 'rhcos'
+      - code: CONFLICTING_GROUP_RPM_INSTALLED
+        component: 'rhcos'


### PR DESCRIPTION
…M_BUILD for rhcos

Apparently, the default permissions for stream get overridden when
adding an extra permission.