### PR TITLE
Bump OpenStack to 16.2

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -263,8 +263,8 @@ repos:
   openstack-16-for-rhel-8-rpms:
     conf:
       baseurl:
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/ppc64le/openstack/16/os/
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/x86_64/openstack/16/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/ppc64le/openstack/16.2/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/x86_64/openstack/16.2/os/
         # XXX: aarch64 and s390x RHOS don't exist, use puddles for now in order to build Ironic
         s390x: http://download-node-02.eng.bos.redhat.com/rcm-guest/puddles/Multi-Arch/OpenStack/16.2/latest/OpenStack/s390x/os/
         aarch64: http://download-node-02.eng.bos.redhat.com/rcm-guest/puddles/Multi-Arch/OpenStack/16.2/latest/OpenStack/aarch64/os/
@@ -274,8 +274,8 @@ repos:
         localdev:
           enabled: true
     content_set:
-      default: openstack-16-for-rhel-8-x86_64-rpms
-      ppc64le: openstack-16-for-rhel-8-ppc64le-rpms
+      default: openstack-16.2-for-rhel-8-x86_64-rpms
+      ppc64le: openstack-16.2-for-rhel-8-ppc64le-rpms
       # don't have content set for aarch64 or s390x
       optional: true
     reposync:


### PR DESCRIPTION
This pulp repo and content set were exclusively for 16.0, which is out
of support.  16.1 and 16.2 are supported in parallel and therefore have
their own repos and content sets.  This also resolves mismatches with
the ARM puddle, which is also 16.2.

/assign @thiagoalessio
