### PR TITLE
4.10: Allow outdated rpms for ose-ovn-kubernetes

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -10,3 +10,5 @@ releases:
         component: 'rhcos'
       - code: CONFLICTING_GROUP_RPM_INSTALLED
         component: 'rhcos'
+      - code: OUTDATED_RPMS_IN_STREAM_BUILD
+        component: 'ose-ovn-kubernetes'


### PR DESCRIPTION
As the rpms are pinned in the Dockerfile, it is expected that the
installed version is not the latest version.