### PR TITLE
update-console-sources: use openshift/base-nodejs

### DIFF
--- a/modifications/update-console-sources
+++ b/modifications/update-console-sources
@@ -46,7 +46,7 @@ dg_repo="${DISTGIT_REPO:-${PWD}}"
 dry_run="${DRY_RUN:-false}"
 #
 # NodeJS builder image to use
-builder_img="${BUILDER_IMAGE:-registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-base:ubi8.nodejs.14}"
+builder_img="${BUILDER_IMAGE:-registry-proxy.engineering.redhat.com/rh-osbs/openshift-base-nodejs:v4.10.0}"
 
 longopts=help,dg-repo:,dg-branch:,dry-run,builder-img:
 options=hr:t:di:


### PR DESCRIPTION
The one question about this is if there is a way to avoid hardcoding the version tag, otherwise it will need to be updated once per branch.﻿
