### PR TITLE
Fix metallb operator bundle

### DIFF
--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -15,7 +15,7 @@ enabled_repos:
 for_payload: false
 from:
   member: openshift-base-rhel8
-name: openshift/ose-frr
+name: openshift/frr-rhel8
 name_in_bundle: metallb-frr-rhel8
 owners:
 - metallb-dev@redhat.com

--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -16,5 +16,6 @@ for_payload: false
 from:
   member: openshift-base-rhel8
 name: openshift/ose-frr
+name_in_bundle: metallb-frr-rhel8
 owners:
 - metallb-dev@redhat.com

--- a/images/ose-frr.yml
+++ b/images/ose-frr.yml
@@ -13,6 +13,8 @@ enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
 for_payload: false
+dependents:
+- ose-metallb-operator
 from:
   member: openshift-base-rhel8
 name: openshift/frr-rhel8


### PR DESCRIPTION
Resolves the following error during rebase of `ose-metallb-operator`:

```
ERROR [containers/ose-metallb-operator] Unable to find metallb-frr-rhel8 in image-references data for ose-metallb-operator
```