### PR TITLE
cluster-node-tuning-operator: Add rhel-8-fast-datapath repo

### DIFF
--- a/images/cluster-node-tuning-operator.yml
+++ b/images/cluster-node-tuning-operator.yml
@@ -14,6 +14,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
+- rhel-8-fast-datapath-rpms
 for_payload: true
 from:
   builder:


### PR DESCRIPTION
This change adds rhel-8-fast-datapath-rpms to the node tuning operator.
See: https://github.com/openshift/cluster-node-tuning-operator/pull/304

Signed-off-by: Jiri Mencak <jmencak@users.noreply.github.com>