### PR TITLE
Adds an extra link to the 3.11 advisory template that directs users t…

### DIFF
--- a/erratatool.yml
+++ b/erratatool.yml
@@ -24,7 +24,6 @@ solution: |
 
   Details on how to access this content are available at https://docs.openshift.com/container-platform/3.11/upgrading/index.html
 
-
 description: |
   Red Hat OpenShift Container Platform is Red Hat's cloud computing Kubernetes application platform solution designed for on-premise or private cloud deployments.
 

--- a/erratatool.yml
+++ b/erratatool.yml
@@ -8,8 +8,6 @@ brew_tag_product_version_mapping:
 
 cdn_repos:
 - rhel-7-server-ose-{MAJOR}_DOT_{MINOR}-rpms__x86_64
-- rhel-7-for-power-le-ose-{MAJOR}_DOT_{MINOR}-rpms__ppc64le
-- rhel-7-for-power-9-ose-{MAJOR}_DOT_{MINOR}-rpms__ppc64le 
 
 release: "RHOSE ASYNC"
 
@@ -24,7 +22,8 @@ solution: |
 
   https://docs.openshift.com/container-platform/3.11/release_notes/ocp_3_11_release_notes.html
 
-  This update is available via the Red Hat Network. Details on how to use the Red Hat Network to apply this update are available at https://access.redhat.com/articles/11258"""
+  Details on how to access this content are available at https://docs.openshift.com/container-platform/3.11/upgrading/index.html
+
 
 description: |
   Red Hat OpenShift Container Platform is Red Hat's cloud computing Kubernetes application platform solution designed for on-premise or private cloud deployments.
@@ -62,11 +61,11 @@ boilerplates:
     solution: &common_solution |
       Before applying this update, ensure all previously released errata relevant to your system is applied.
 
-      See the following documentation, which will be updated shortly for release 3.11.z, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
+      For OpenShift Container Platform 3.11 see the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
 
       https://docs.openshift.com/container-platform/3.11/release_notes/ocp_3_11_release_notes.html
 
-      This update is available via the Red Hat Network. Details on how to use the Red Hat Network to apply this update are available at https://access.redhat.com/articles/11258
+      Details on how to access this content are available at https://docs.openshift.com/container-platform/3.11/upgrading/index.html
   image:
     synopsis: "OpenShift Container Platform 3.11.z images update"
     topic: *common_topic


### PR DESCRIPTION
With this template update, I've added a link to the 3.11 Upgrade page. This mirrors what we do in OCP 4.y.z versions, where there are two links included in the Solutions section of the advisory. 