### PR TITLE
Updates to advisory text 4.6

### DIFF
--- a/erratatool.yml
+++ b/erratatool.yml
@@ -27,7 +27,7 @@ description: |
 
   This advisory contains the RPM packages / container images for Red Hat OpenShift Container Platform 4.6.z. See the following advisory for the container images / RPM packages for this release:
 
-  <ADVISORY_URL> e.g. https://access.redhat.com/errata/RHBA-2021:1234
+  <ADVISORY_URL> e.g. https://access.redhat.com/errata/RHBA-2022:1234
 
   Space precludes documenting all of the bug fixes and enhancements in this advisory, as well as all of the container images in this advisory. See the following Release Notes documentation, which will be updated shortly for this release, for details about these changes:
 
@@ -73,7 +73,7 @@ boilerplates:
 
       This advisory contains the RPM packages for Red Hat OpenShift Container Platform 4.6.z. See the following advisory for the container images for this release:
 
-      <ADVISORY_URL> e.g. https://access.redhat.com/errata/RHBA-2021:1234
+      <ADVISORY_URL> e.g. https://access.redhat.com/errata/RHBA-2022:1234
 
       All OpenShift Container Platform 4.6 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.6/updating/updating-cluster-between-minor.html#understanding-upgrade-channels_updating-cluster-between-minor
     solution: &common_solution |
@@ -90,7 +90,7 @@ boilerplates:
 
       This advisory contains the container images for Red Hat OpenShift Container Platform 4.6.z. See the following advisory for the RPM packages for this release:
 
-      <ADVISORY_URL> e.g. https://access.redhat.com/errata/RHBA-2021:1234
+      <ADVISORY_URL> e.g. https://access.redhat.com/errata/RHBA-2022:1234
 
       Space precludes documenting all of the container images in this advisory. See the following Release Notes documentation, which will be updated shortly for this release, for details about these changes:
 


### PR DESCRIPTION
Updating the advisory boilerplate: 2021 --> 2022.