### PR TITLE
Updates to advisory texts 3.11

### DIFF
--- a/erratatool.yml
+++ b/erratatool.yml
@@ -29,7 +29,7 @@ description: |
 
   This advisory contains the RPM packages for Red Hat OpenShift Container Platform 3.11.z. See the following advisory for the container images for this release:
 
-  https://access.redhat.com/errata/RHBA-2020:1234
+  https://access.redhat.com/errata/RHBA-2022:1234
 
   Space precludes documenting all of the bug fixes and enhancements in this advisory. See the following Release Notes documentation, which will be updated shortly for this release, for details about these changes:
 
@@ -50,7 +50,7 @@ boilerplates:
 
       This advisory contains the RPM packages for Red Hat OpenShift Container Platform 3.11.z. See the following advisory for the container images for this release:
 
-      [[Advisory URL]] https://access.redhat.com/errata/RHBA-2020:1234
+      [[Advisory URL]] https://access.redhat.com/errata/RHBA-2022:1234
 
       This release fixes the following bugs:
 
@@ -73,7 +73,7 @@ boilerplates:
 
       This advisory contains the container images for Red Hat OpenShift Container Platform 3.11.z. See the following advisory for the RPM packages for this release:
 
-      [[Advisory URL]] https://access.redhat.com/errata/RHBA-2020:1234
+      [[Advisory URL]] https://access.redhat.com/errata/RHBA-2022:1234
 
       Space precludes documenting all of the container images in this advisory. See the following Release Notes documentation, which will be updated shortly for this release, for details about these images:
 


### PR DESCRIPTION
Updating the advisory boilerplate: 2021 --> 2022.