### PR TITLE
Remove duplicate "art3594" release definition

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -98,34 +98,6 @@ releases:
           metadata:
             is:
               nvr: elasticsearch-operator-container-v4.6.0-202112132021.p0.gd421c69.assembly.stream
-  art3594:
-    assembly:
-      type: custom
-      basis:
-        assembly: "4.6.52"
-        reference_releases!: {}
-      members:
-        images:
-        - distgit_key: hive
-          why: fix a CVE
-          metadata:
-            is:
-              nvr: hive-container-v4.6.0-202112140546.p0.g8b9da97.assembly.stream
-        - distgit_key: ose-metering-ansible-operator
-          why: fix a CVE
-          metadata:
-            is:
-              nvr: ose-metering-ansible-operator-container-v4.6.0-202112140831.p0.gd74112d.assembly.art3594
-        - distgit_key: logging-elasticsearch6
-          why: fix a CVE
-          metadata:
-            is:
-              nvr: logging-elasticsearch6-container-v4.6.0-202112132021.p0.g2a13a81.assembly.stream
-        - distgit_key: elasticsearch-operator
-          why: fix a CVE
-          metadata:
-            is:
-              nvr: elasticsearch-operator-container-v4.6.0-202112132021.p0.gd421c69.assembly.stream
   4.6.52:
     assembly:
       basis:


### PR DESCRIPTION
It is preventing me from preparing the next release, since it complains about "duplicate key"