### PR TITLE
Force correct build of ose-metering-ansible-operator on 4.6.53

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -24,7 +24,10 @@ releases:
           metadata: 86263
         release_jira: OCPPLAN-8124
       members:
-        images: []
+        images:
+        - distgit_key: ose-metering-ansible-operator
+          metadata:
+            is: ose-metering-ansible-operator-container-v4.6.0-202201051015.p0.gd74112d.assembly.stream
         rpms: []
       rhcos:
         machine-os-content:


### PR DESCRIPTION
"elliott find-builds" is finding `ose-metering-ansible-operator-container-v4.6.0-202112160147.p0.gd74112d.assembly.stream`, which is not correctly tagged.