### PR TITLE
Remove OSP repo dependencies from ironic images

### DIFF
--- a/images/ironic-agent.yml
+++ b/images/ironic-agent.yml
@@ -29,4 +29,3 @@ enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
 - rhel-8-server-ose-rpms-embargoed
-- openstack-16-for-rhel-8-rpms

--- a/images/ironic-hardware-inventory-recorder-image.yml
+++ b/images/ironic-hardware-inventory-recorder-image.yml
@@ -16,7 +16,6 @@ enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
 - rhel-8-server-ose-rpms-embargoed
-- openstack-16-for-rhel-8-rpms
 for_payload: true
 from:
   member: openshift-base-rhel8

--- a/images/ironic-rhcos-downloader.yml
+++ b/images/ironic-rhcos-downloader.yml
@@ -12,7 +12,6 @@ enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
 - rhel-8-server-ose-rpms-embargoed
-- openstack-16-for-rhel-8-rpms
 for_payload: true
 from:
   builder:

--- a/images/ironic-static-ip-manager.yml
+++ b/images/ironic-static-ip-manager.yml
@@ -12,7 +12,6 @@ enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
 - rhel-8-server-ose-rpms-embargoed
-- openstack-16-for-rhel-8-rpms
 for_payload: true
 from:
   member: openshift-base-rhel8

--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -12,7 +12,6 @@ enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
 - rhel-8-server-ose-rpms-embargoed
-- openstack-16-for-rhel-8-rpms
 for_payload: true
 from:
   builder:


### PR DESCRIPTION
The OSP repositories should not be needed to build ironic images anymore.