### PR TITLE
Bug 2036043: Update logging-elasticsearch5.yml 

### DIFF
--- a/images/logging-elasticsearch5.yml
+++ b/images/logging-elasticsearch5.yml
@@ -14,7 +14,7 @@ enabled_repos:
 - rhel-server-optional-rpms
 - rhel-server-ose-rpms-embargoed
 from:
-  member: openshift-base-elasticsearch
+  member: openshift-base-rhel7
 labels:
   License: GPLv2+
   io.k8s.description: Elasticsearch container for EFK aggregated logging storage
@@ -24,7 +24,7 @@ labels:
 name: openshift3/ose-logging-elasticsearch5
 owners:
 - jcantril@redhat.com
-- ewolinet@redhat.com
+- team-logging@redhat.com
 push:
   repos:
   - openshift3/logging-elasticsearch5


### PR DESCRIPTION
This updates the base image to base RHEL to allow building of Elasticsearch image using Elasticsearch built from PNC