### PR TITLE
4.6.54 to include #2036040 fix

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -15,8 +15,41 @@ releases:
           metadata: 87069
         upgrades: 4.5.16,4.5.17,4.5.18,4.5.19,4.5.20,4.5.21,4.5.22,4.5.23,4.5.24,4.5.25,4.5.27,4.5.28,4.5.29,4.5.30,4.5.31,4.5.32,4.5.33,4.5.34,4.5.35,4.5.36,4.5.37,4.5.38,4.5.39,4.5.40,4.5.41,4.6.1,4.6.2,4.6.3,4.6.4,4.6.5,4.6.6,4.6.7,4.6.8,4.6.9,4.6.10,4.6.12,4.6.13,4.6.15,4.6.16,4.6.17,4.6.18,4.6.19,4.6.20,4.6.21,4.6.22,4.6.23,4.6.24,4.6.25,4.6.26,4.6.27,4.6.28,4.6.29,4.6.30,4.6.31,4.6.32,4.6.33,4.6.34,4.6.35,4.6.36,4.6.37,4.6.38,4.6.39,4.6.40,4.6.41,4.6.42,4.6.43,4.6.44,4.6.45,4.6.46,4.6.47,4.6.48,4.6.49,4.6.50,4.6.51,4.6.52,4.6.53
         release_jira: OCPPLAN-8244
+      issues:
+        include:
+        - id: 2036040
       members:
-        images: []
+        images:
+        - distgit_key: logging-curator5
+          why: BZ2036040 addressed
+          metadata:
+            is:
+              nvr: logging-curator5-container-v4.6.0-202201181437.p0.g181b827.assembly.stream
+        - distgit_key: logging-elasticsearch6
+          why: BZ2036040 addressed
+          metadata:
+            is:
+              nvr: logging-elasticsearch6-container-v4.6.0-202201181437.p0.g181b827.assembly.stream
+        - distgit_key: logging-fluentd
+          why: BZ2036040 addressed
+          metadata:
+            is:
+              nvr: logging-fluentd-container-v4.6.0-202201181437.p0.g181b827.assembly.stream
+        - distgit_key: logging-kibana6
+          why: BZ2036040 addressed
+          metadata:
+            is:
+              nvr: logging-kibana6-container-v4.6.0-202201181437.p0.g181b827.assembly.stream
+        - distgit_key: elasticsearch-operator
+          why: BZ2036040 addressed
+          metadata:
+            is:
+              nvr: elasticsearch-operator-container-v4.6.0-202201181437.p0.gd421c69.assembly.stream
+        - distgit_key: cluster-logging-operator
+          why: BZ2036040 addressed
+          metadata:
+            is:
+              nvr: cluster-logging-operator-container-v4.6.0-202201181437.p0.g7f7eccc.assembly.stream
         rpms: []
       rhcos:
         machine-os-content:


### PR DESCRIPTION
https://coreos.slack.com/archives/CJARLA942/p1642796895105200

bundle nvrs to go with this
- cluster-logging-operator-metadata-container-v4.6.0.202201181437.p0.g7f7eccc.assembly.stream-1
- elasticsearch-operator-metadata-container-v4.6.0.202201181437.p0.gd421c69.assembly.stream-1