### PR TITLE
[ART-3709] Disable Ironic images on aarch64 in 4.10

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -265,9 +265,9 @@ repos:
       baseurl:
         ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/ppc64le/openstack/16.2/os/
         x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/x86_64/openstack/16.2/os/
-        # XXX: aarch64 and s390x RHOS don't exist, use puddles for now in order to build Ironic
-        s390x: http://download-node-02.eng.bos.redhat.com/rcm-guest/puddles/Multi-Arch/OpenStack/16.2/latest/OpenStack/s390x/os/
-        aarch64: http://download-node-02.eng.bos.redhat.com/rcm-guest/puddles/Multi-Arch/OpenStack/16.2/latest/OpenStack/aarch64/os/
+        # XXX: aarch64 and s390x RHOS don't exist, pointing at something that exists
+        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/x86_64/openstack/16.2/os/
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/x86_64/openstack/16.2/os/
       ci_alignment:
         profiles:
         - el8

--- a/images/ironic-agent.yml
+++ b/images/ironic-agent.yml
@@ -1,6 +1,5 @@
 arches:
 - x86_64
-- aarch64
 container_yaml:
   go:
     modules:

--- a/images/ironic-hardware-inventory-recorder-image.yml
+++ b/images/ironic-hardware-inventory-recorder-image.yml
@@ -1,6 +1,5 @@
 arches:
 - x86_64
-- aarch64
 container_yaml:
   go:
     modules:

--- a/images/ironic-rhcos-downloader.yml
+++ b/images/ironic-rhcos-downloader.yml
@@ -1,6 +1,5 @@
 arches:
 - x86_64
-- aarch64
 content:
   source:
     dockerfile: Dockerfile.ocp

--- a/images/ironic-static-ip-manager.yml
+++ b/images/ironic-static-ip-manager.yml
@@ -1,6 +1,5 @@
 arches:
 - x86_64
-- aarch64
 content:
   source:
     dockerfile: Dockerfile.ocp

--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -1,6 +1,5 @@
 arches:
 - x86_64
-- aarch64
 content:
   source:
     dockerfile: Dockerfile.ocp

--- a/images/ose-image-customization-controller.yml
+++ b/images/ose-image-customization-controller.yml
@@ -1,6 +1,5 @@
 arches:
 - x86_64
-- aarch64
 container_yaml:
   go:
     modules:

--- a/images/ose-machine-os-images.yml
+++ b/images/ose-machine-os-images.yml
@@ -1,6 +1,5 @@
 arches:
 - x86_64
-- aarch64
 container_yaml:
   go:
     modules:


### PR DESCRIPTION
This is for 4.10 ONLY and should NOT be carried forward to 4.11.﻿
