### PR TITLE
Revert "Remove OSP repo dependencies from ironic images"

### DIFF
--- a/images/ironic-agent.yml
+++ b/images/ironic-agent.yml
@@ -29,3 +29,4 @@ enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
 - rhel-8-server-ose-rpms-embargoed
+- openstack-16-for-rhel-8-rpms

--- a/images/ironic-hardware-inventory-recorder-image.yml
+++ b/images/ironic-hardware-inventory-recorder-image.yml
@@ -16,6 +16,7 @@ enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
 - rhel-8-server-ose-rpms-embargoed
+- openstack-16-for-rhel-8-rpms
 for_payload: true
 from:
   member: openshift-base-rhel8

--- a/images/ironic-rhcos-downloader.yml
+++ b/images/ironic-rhcos-downloader.yml
@@ -12,6 +12,7 @@ enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
 - rhel-8-server-ose-rpms-embargoed
+- openstack-16-for-rhel-8-rpms
 for_payload: true
 from:
   builder:

--- a/images/ironic-static-ip-manager.yml
+++ b/images/ironic-static-ip-manager.yml
@@ -12,6 +12,7 @@ enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
 - rhel-8-server-ose-rpms-embargoed
+- openstack-16-for-rhel-8-rpms
 for_payload: true
 from:
   member: openshift-base-rhel8

--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -12,6 +12,7 @@ enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
 - rhel-8-server-ose-rpms-embargoed
+- openstack-16-for-rhel-8-rpms
 for_payload: true
 from:
   builder:


### PR DESCRIPTION
Reverts openshift/ocp-build-data#1273

Quite some dependencies are missing as it is, see e.g. [this build](http://download.eng.bos.redhat.com/brewroot/work/tasks/8321/42658321/x86_64.log). Proposing to revert this change to get 4.11 nightlies rolling.

