### PR TITLE
4.8: Fixed broken link in advisory templates

### DIFF
--- a/erratatool.yml
+++ b/erratatool.yml
@@ -53,7 +53,7 @@ description: |
 
       The image digest is sha256:<SHASUM_HERE>
 
-  All OpenShift Container Platform 4.8 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.8/updating/updating-cluster-between-minor.html#understanding-upgrade-channels_updating-cluster-between-minor
+  All OpenShift Container Platform 4.8 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.8/updating/updating-cluster-cli.html
 
 solution: |
   For OpenShift Container Platform 4.8 see the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
@@ -75,7 +75,7 @@ boilerplates:
 
       <ADVISORY_URL> e.g. https://access.redhat.com/errata/RHBA-2022:1234
 
-      All OpenShift Container Platform 4.8 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.8/updating/updating-cluster-between-minor.html#understanding-upgrade-channels_updating-cluster-between-minor
+      All OpenShift Container Platform 4.8 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.8/updating/updating-cluster-cli.html
     solution: &common_solution |
       For OpenShift Container Platform 4.8 see the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
 
@@ -116,7 +116,7 @@ boilerplates:
 
           The image digest is sha256:<SHASUM_HERE>
 
-      All OpenShift Container Platform 4.8 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.8/updating/updating-cluster-between-minor.html#understanding-upgrade-channels_updating-cluster-between-minor
+      All OpenShift Container Platform 4.8 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.8/updating/updating-cluster-cli.html
     solution: *common_solution
   extras:
     synopsis: OpenShift Container Platform 4.8.z extras update
@@ -135,7 +135,7 @@ boilerplates:
 
       This advisory will be used to release the corresponding Operator manifests via new Operator metadata containers.
 
-      All OpenShift Container Platform 4.8 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.8/updating/updating-cluster-between-minor.html#understanding-upgrade-channels_updating-cluster-between-minor
+      All OpenShift Container Platform 4.8 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.8/updating/updating-cluster-cli.html
     solution: *common_solution
   cve:
     synopsis: OpenShift Container Platform 4.8.z security update


### PR DESCRIPTION
This PR fixes a broken link in the advisory templates.

@stevsmit PTAL