### PR TITLE
[rhel8] build from 4.9 buildroot instead

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -8,7 +8,7 @@ arches:
 
 vars:
   MAJOR: 4
-  MINOR: 8
+  MINOR: 9
 
 urls:
   brewhub: https://brewhub.engineering.redhat.com/brewhub

--- a/images/openshift-golang-builder.yml
+++ b/images/openshift-golang-builder.yml
@@ -7,8 +7,6 @@ content:
       branch:
         target: rhel-8-golang-1.16
       url: git@github.com:openshift/ocp-build-data.git
-distgit:
-  branch: rhaos-4.8-rhel-8
 enabled_repos:
 - rhel-8-server-ose-build-rpms
 # for clang


### PR DESCRIPTION
In cases where we want to follow the backport process, we'll need to update buildroots in the highest release first. So, move to the newest release that uses a golang version, in this case 4.9 for go 1.16.