### PR TITLE
4.11: Consume 4.11 rhcos

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -54,9 +54,6 @@ urls:
   brew_image_host: registry-proxy.engineering.redhat.com
   brew_image_namespace: rh-osbs
   cgit: http://pkgs.devel.redhat.com/cgit
-  # temporarily point RHCOS elsewhere when needed
-  rhcos_release_base:
-    ppc64le: https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.10-ppc64le
 dist_git_ignore:
   - gating.yaml
 


### PR DESCRIPTION
This waits on [ppc64le rhcos build](https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.11-ppc64le/builds.json) being available.