### PR TITLE
Get m-o-c to 4.11

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -56,10 +56,7 @@ urls:
   cgit: http://pkgs.devel.redhat.com/cgit
   # temporarily point RHCOS elsewhere when needed
   rhcos_release_base:
-    x86_64: https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.10
-    s390x: https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.10-s390x
     ppc64le: https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.10-ppc64le
-    aarch64: https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.10-aarch64
 dist_git_ignore:
   - gating.yaml
 


### PR DESCRIPTION
For all arches except ppc64le, as there is not yet a succesful build
there.