### PR TITLE
Use pulp repo for FDP on aarch64

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -240,12 +240,12 @@ repos:
         x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/x86_64/fast-datapath/os/
         ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/ppc64le/fast-datapath/os/
         s390x: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/s390x/fast-datapath/os/
-        # FDP has yet to be released for aarch64
-        aarch64: http://download.lab.bos.redhat.com/rcm-guest/puddles/Multi-Arch/Fast-DataPath/EL8-Production/latest/aarch64/os/
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/aarch64/fast-datapath/os/
         # [lmeyer] multi-arch releases might lag behind x86_64, which may require pointing at pre-release MA composes.
         # however this must be a temporary solution only; will cause mismatches after further releases if left that way.
         # ppc64le: http://download.lab.bos.redhat.com/rcm-guest/puddles/Multi-Arch/Fast-DataPath/EL8-Production/latest/ppc64le/os/
         # s390x: http://download.lab.bos.redhat.com/rcm-guest/puddles/Multi-Arch/Fast-DataPath/EL8-Production/latest/s390x/os/
+        # aarch64: http://download.lab.bos.redhat.com/rcm-guest/puddles/Multi-Arch/Fast-DataPath/EL8-Production/latest/aarch64/os/
       ci_alignment:
         profiles:
         - el8


### PR DESCRIPTION
FDP 22.A enabled aarch64 and included most current versions, except for openvswitch2.16, but we are using a cross-tagged (and version pinned) build of that anyway.

This is for 4.11; once we have confirmed that FDP-consuming images (listed below) build successfully (without component mismatches) then this should be backported to 4.10 (keeping freezes in mind) and 4.9.

cluster-node-tuning-operator
ose-ovn-kubernetes
ose-sdn