### PR TITLE
Cachito: Disable pip and yarn package manager magics

### DIFF
--- a/images/grafana.yml
+++ b/images/grafana.yml
@@ -5,6 +5,7 @@ content:
       branch:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/grafana.git
+    pkg_managers: ["gomod"]  # FIXME: Don't use yarn package manager magic in Cachito
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms

--- a/images/kuryr-cni.yml
+++ b/images/kuryr-cni.yml
@@ -8,6 +8,7 @@ content:
       branch:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/kuryr-kubernetes.git
+    pkg_managers: []  # FIXME: Don't use pip package manager magic in Cachito
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms

--- a/images/kuryr-controller.yml
+++ b/images/kuryr-controller.yml
@@ -8,6 +8,7 @@ content:
       branch:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/kuryr-kubernetes.git
+    pkg_managers: []  # FIXME: Don't use pip package manager magic in Cachito
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms

--- a/images/logging-curator5.yml
+++ b/images/logging-curator5.yml
@@ -6,6 +6,7 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/origin-aggregated-logging.git
     path: curator
+    pkg_managers: []  # FIXME: Don't use pip package manager magic in Cachito
 dependents:
 - cluster-logging-operator
 distgit:


### PR DESCRIPTION
Builds fail when those package manager magics are used. Disable for now.