### PR TITLE
Revert "[openshift-4.10] Hypershift should be included in release payloads"

### DIFF
--- a/images/hypershift.yml
+++ b/images/hypershift.yml
@@ -18,7 +18,7 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-for_payload: true
+for_payload: false
 from:
   builder:
   - stream: golang


### PR DESCRIPTION
Reverts openshift/ocp-build-data#1360 - this can wait until 4.10.1