### PR TITLE
Revert "Revert "[openshift-4.10] Hypershift should be included in release payloads""

### DIFF
--- a/images/hypershift.yml
+++ b/images/hypershift.yml
@@ -18,7 +18,7 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-for_payload: false
+for_payload: true
 from:
   builder:
   - stream: golang


### PR DESCRIPTION
Reverts openshift/ocp-build-data#1362 - Merge after 4.10 GA to include in 4.10.1