### PR TITLE
[ART-3854] base image -> ELS and update w/ OSE repo

### DIFF
--- a/images/openshift-base-rhel8.yml
+++ b/images/openshift-base-rhel8.yml
@@ -7,7 +7,7 @@ content:
       url: git@github.com:openshift/ocp-build-data.git
     ci_alignment:
       streams_prs:
-        enabled: false    
+        enabled: false
       mirror: true
       # The upstream_image_base serves as a starting point for the upstream_image.
       # ART will mirror the brew build out to upstream_image_base.
@@ -24,6 +24,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: false
 for_release: false
 from:

--- a/streams.yml
+++ b/streams.yml
@@ -72,9 +72,10 @@ rhel-7-golang:
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-7-golang-1.17-openshift-{MAJOR}.{MINOR}
 
 rhel8:
-  # the most recent release at present. since we yum update this, maybe it does not need to float.
-  # but it is important that we not build from unreleased builds.
-  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi8:8.4-213
+  # the most recent 8.4.z release at present (we must not build from unreleased builds so this cannot be a floating tag).
+  # ref ART-3854 for why we need the ELS image rather than just updating an old UBI8 image.
+  # rhel-els-container-8.4-141.1645698807
+  image: registry-proxy.engineering.redhat.com/rh-osbs/rhel-els@sha256:9aed89552a06a424b01c12f96d8878cdf02e056259955fbfc30f26b8acf99f20
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-openshift-{MAJOR}.{MINOR}.art
   mirror: true
 


### PR DESCRIPTION
In addition to updating the base image, we discovered our consistency
checks were complaining about things present in the base image but
updated by our candidate repo; because not all images use our candidate
repo, they ended up with different contents that triggered the checks.
This also caused problems with cross-arch consistency checks in the OSBS
build.

So, the simplest solution is just to update base image contents with
candidate content where relevant.