### PR TITLE
Disable cachito for failed images

### DIFF
--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -1,3 +1,9 @@
+cachito:
+  enabled: false
+container_yaml:		
+￼ go:
+￼   modules:
+￼   - module: github.com/operator-framework/operator-sdk
 content:
   source:
     dockerfile: release/ansible/Dockerfile.rhel8

--- a/images/openshift-enterprise-helm-operator.yml
+++ b/images/openshift-enterprise-helm-operator.yml
@@ -1,3 +1,9 @@
+cachito:
+  enabled: false
+container_yaml:		
+￼ go:
+￼   modules:
+￼   - module: github.com/operator-framework/operator-sdk
 content:
   source:
     dockerfile: release/helm/Dockerfile

--- a/images/openshift-enterprise-operator-sdk.yml
+++ b/images/openshift-enterprise-operator-sdk.yml
@@ -1,3 +1,9 @@
+cachito:
+  enabled: false
+container_yaml:		
+￼ go:
+￼   modules:
+￼   - module: github.com/operator-framework/operator-sdk
 content:
   source:
     dockerfile: release/sdk/Dockerfile

--- a/images/openshift-kubernetes-nmstate-handler.yml
+++ b/images/openshift-kubernetes-nmstate-handler.yml
@@ -1,3 +1,9 @@
+cachito:
+  enabled: false
+container_yaml:		
+￼ go:
+￼   modules:
+￼   - module: github.com/openshift/kubernetes-nmstate
 content:
   source:
     dockerfile: build/Dockerfile.openshift

--- a/images/openshift-kubernetes-nmstate-operator.yml
+++ b/images/openshift-kubernetes-nmstate-operator.yml
@@ -1,3 +1,9 @@
+cachito:
+  enabled: false
+container_yaml:		
+￼ go:
+￼   modules:
+￼   - module: github.com/openshift/kubernetes-nmstate
 content:
   source:
     dockerfile: build/Dockerfile.operator.openshift

--- a/images/ose-aws-efs-csi-driver-operator.yml
+++ b/images/ose-aws-efs-csi-driver-operator.yml
@@ -3,6 +3,10 @@ arches:
 - aarch64
 cachito:
   enabled: false # This is a python image, not sure how to deal with this
+container_yaml:		
+￼ go:
+￼   modules:
+￼   - module: github.com/openshift/aws-efs-csi-driver-operator
 content:
   source:
     dockerfile: Dockerfile

--- a/images/ose-aws-efs-csi-driver.yml
+++ b/images/ose-aws-efs-csi-driver.yml
@@ -3,6 +3,10 @@ arches:
 - aarch64
 cachito:
   enabled: false # This is a python image, not sure how to deal with this
+container_yaml:		
+￼ go:
+￼   modules:
+￼   - module: github.com/openshift/aws-efs-csi-driver
 content:
   source:
     dockerfile: Dockerfile.openshift


### PR DESCRIPTION
from the 4.10 failed job https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Focp4/26789/
the following images failed to build
 ose-aws-efs-csi-driver,
openshift-enterprise-helm-operator,
openshift-enterprise-operator-sdk,
openshift-enterprise-ansible-operator,
openshift-kubernetes-nmstate-operator,
openshift-kubernetes-nmstate-handler