### PR TITLE
Update Cachito configuration for aws-efs-csi-driver, aws-efs-utils

### DIFF
--- a/images/ose-aws-efs-csi-driver.yml
+++ b/images/ose-aws-efs-csi-driver.yml
@@ -2,8 +2,8 @@ arches:
 - x86_64
 - aarch64
 cachito:
-  enabled: false # This is a python image, not sure how to deal with this
-container_yaml:		
+  enabled: false  # FIXME: Temporarily disable Cachito until bug 2063117 is resolved.
+container_yaml:
 ￼ go:
 ￼   modules:
 ￼   - module: github.com/openshift/aws-efs-csi-driver

--- a/images/ose-aws-efs-utils.yml
+++ b/images/ose-aws-efs-utils.yml
@@ -11,6 +11,7 @@ content:
       branch:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/aws-efs-utils.git
+    pkg_managers: [] # FIXME: Don't use pip package manager magic in Cachito
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms


### PR DESCRIPTION
- aws-efs-utils
Cachito can be enabled but use empty package managers to provision sources only.

- aws-efs-csi-driver
The comment is not corrected. Updated.