### PR TITLE
4.10: Remove tabs and spaces

### DIFF
--- a/images/openshift-enterprise-ansible-operator.yml
+++ b/images/openshift-enterprise-ansible-operator.yml
@@ -1,6 +1,6 @@
 cachito:
   enabled: false
-container_yaml:		
+container_yaml:
 ￼ go:
 ￼   modules:
 ￼   - module: github.com/operator-framework/operator-sdk

--- a/images/openshift-enterprise-helm-operator.yml
+++ b/images/openshift-enterprise-helm-operator.yml
@@ -1,6 +1,6 @@
 cachito:
   enabled: false
-container_yaml:		
+container_yaml:
 ￼ go:
 ￼   modules:
 ￼   - module: github.com/operator-framework/operator-sdk

--- a/images/openshift-enterprise-operator-sdk.yml
+++ b/images/openshift-enterprise-operator-sdk.yml
@@ -1,6 +1,6 @@
 cachito:
   enabled: false
-container_yaml:		
+container_yaml:
 ￼ go:
 ￼   modules:
 ￼   - module: github.com/operator-framework/operator-sdk

--- a/images/openshift-kubernetes-nmstate-handler.yml
+++ b/images/openshift-kubernetes-nmstate-handler.yml
@@ -1,6 +1,6 @@
 cachito:
   enabled: false
-container_yaml:		
+container_yaml:
 ￼ go:
 ￼   modules:
 ￼   - module: github.com/openshift/kubernetes-nmstate

--- a/images/openshift-kubernetes-nmstate-operator.yml
+++ b/images/openshift-kubernetes-nmstate-operator.yml
@@ -1,6 +1,6 @@
 cachito:
   enabled: false
-container_yaml:		
+container_yaml:
 ￼ go:
 ￼   modules:
 ￼   - module: github.com/openshift/kubernetes-nmstate

--- a/images/ose-aws-efs-csi-driver-operator.yml
+++ b/images/ose-aws-efs-csi-driver-operator.yml
@@ -3,7 +3,7 @@ arches:
 - aarch64
 cachito:
   enabled: false # This is a python image, not sure how to deal with this
-container_yaml:		
+container_yaml:
 ￼ go:
 ￼   modules:
 ￼   - module: github.com/openshift/aws-efs-csi-driver-operator


### PR DESCRIPTION
to prevent errors like:
```
yaml.scanner.ScannerError: while scanning for the next token
found character '\t' that cannot start any token
  in "<unicode string>", line 3, column 16:
    container_yaml:
```

https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Focp4/26798/console