### PR TITLE
4.10: Enable cachito for ose-aws-efs-csi-driver

### DIFF
--- a/images/ose-aws-efs-csi-driver.yml
+++ b/images/ose-aws-efs-csi-driver.yml
@@ -1,12 +1,6 @@
 arches:
 - x86_64
 - aarch64
-cachito:
-  enabled: false  # FIXME: Temporarily disable Cachito until bug 2063117 is resolved.
-container_yaml:
-  go:
-    modules:
-    - module: github.com/openshift/aws-efs-csi-driver
 content:
   source:
     dockerfile: Dockerfile.openshift


### PR DESCRIPTION
As https://bugzilla.redhat.com/show_bug.cgi?id=2063117 has been claimed
to be fixed.