### PR TITLE
Set build concurrency installer-artifacts to 1

### DIFF
--- a/images/ose-installer-artifacts.yml
+++ b/images/ose-installer-artifacts.yml
@@ -8,7 +8,7 @@ content:
     modifications:
     - action: replace
       match: "hack/build.sh"
-      replacement: "GOFLAGS='-mod=vendor -p=4' hack/build.sh"
+      replacement: "GOFLAGS='-mod=vendor -p=1' hack/build.sh"
     ci_alignment:
       streams_prs:
         ci_build_root:


### PR DESCRIPTION
This build takes long, and fails often on arm64. Most of the time in the
build, it is downloading and gzipping isos. This commit proposes to
disable concurrency in the go build process to not have it fail on this.