### PR TITLE
Revert "Set build concurrency installer-artifacts to 1"

### DIFF
--- a/images/ose-installer-artifacts.yml
+++ b/images/ose-installer-artifacts.yml
@@ -8,7 +8,7 @@ content:
     modifications:
     - action: replace
       match: "hack/build.sh"
-      replacement: "GOFLAGS='-mod=vendor -p=1' hack/build.sh"
+      replacement: "GOFLAGS='-mod=vendor -p=4' hack/build.sh"
     ci_alignment:
       streams_prs:
         ci_build_root:


### PR DESCRIPTION
Reverts openshift/ocp-build-data#1445

This PR also sets the concurrency of `go generate` to 1, which is causing timeouts. Reverting for now.