### PR TITLE
Limit arches of ose-powervs-cloud-controller-manager

### DIFF
--- a/images/ose-powervs-cloud-controller-manager.yml
+++ b/images/ose-powervs-cloud-controller-manager.yml
@@ -1,3 +1,6 @@
+arches:
+- x86_64
+- ppc64le
 content:
   source:
     dockerfile: openshift-hack/images/Dockerfile.openshift


### PR DESCRIPTION
PowerVS is limited to ppc64le, but x86_64 needs to be included for now in all images due to ART-3417.

This is a follow-up to #1451.

/cc @locriandev @joepvd
