### PR TITLE
[ART-3664] build 4.8 with go 1.16.12 builders

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -28,8 +28,8 @@ rhel-7-ci-build-root:
   upstream_image: registry.ci.openshift.org/openshift/release:rhel-7-release-openshift-{MAJOR}.{MINOR}
 
 golang:
-  # openshift-golang-builder-container-v1.16.6-202107291435.el8.git.83c4106
-  image: openshift/golang-builder@sha256:2c34135dc4d4a35fa19775e4e559e2e6f2e476a0ccdc993360e3663729904035
+  # openshift-golang-builder-container-v1.16.12-202202072221.el8.g92a7afd
+  image: openshift/golang-builder@sha256:21aab8ec0f5d119e4f6dab12f7ad6a1cec15d5f9071ae0c7431be760f29d4c71
   mirror: true
   transform: rhel-8/golang
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-{MAJOR}.{MINOR}.art
@@ -59,8 +59,8 @@ etcd_golang:
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-etcd-golang-1.12
 
 rhel-7-golang:
-  # openshift-golang-builder-container-v1.16.6-202111041714.el7.git.c61421d
-  image: openshift/golang-builder@sha256:47317bfa175035744299a2a6a814131199756142deb4082847aca88edf6766bd
+  # openshift-golang-builder-container-v1.16.12-202202120022.el7.g8382039
+  image: openshift/golang-builder@sha256:fbb71aee0451e2639fdc041bb4d5ed7fa875398f3d1d2203a000548596ebddcc
   mirror: true
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-7-golang-1.16-openshift-{MAJOR}.{MINOR}.art
   # dptp will layer yum repos / extra packages on top of ART's image to create the


### PR DESCRIPTION
... except etcd which is still stuck using 1.12

Requisite image PRs are complete:
- https://github.com/openshift/kubernetes/pull/1173
- https://github.com/openshift/oauth-apiserver/pull/74
- https://github.com/openshift/openshift-apiserver/pull/280

The images are the parts we care about here, but we'll follow up to update the buildroots as well for RPM builds.