### PR TITLE
Stop building deprecated image (jenkins-agent-nodejs-10-rhel7)

### DIFF
--- a/images/jenkins-agent-nodejs-10-rhel7.yml
+++ b/images/jenkins-agent-nodejs-10-rhel7.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   source:
     dockerfile: Dockerfile.rhel7


### PR DESCRIPTION
Related conversation: https://coreos.slack.com/archives/CB95J6R4N/p1648475650505609