### PR TITLE
[ART-3889] Add ose-azure-cluster-api-controllers

### DIFF
--- a/images/ose-azure-cluster-api-controllers.yml
+++ b/images/ose-azure-cluster-api-controllers.yml
@@ -1,3 +1,6 @@
+arches:
+- x86_64
+- aarch64
 mode: wip
 content:
   source:

--- a/images/ose-azure-cluster-api-controllers.yml
+++ b/images/ose-azure-cluster-api-controllers.yml
@@ -1,0 +1,22 @@
+mode: wip
+content:
+  source:
+    dockerfile: openshift/Dockerfile.openshift
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/cluster-api-provider-azure.git
+enabled_repos:
+- rhel-8-baseos-rpms
+- rhel-8-appstream-rpms
+for_payload: true
+from:
+  builder:
+  - stream: golang
+  member: openshift-enterprise-base
+name: openshift/ose-azure-cluster-api-controllers
+owners:
+- mfedosin@redhat.com
+- jspeed@redhat.com
+- elmiko@redhat.com
+- dmoiseev@redhat.com

--- a/images/ose-azure-cluster-api-controllers.yml
+++ b/images/ose-azure-cluster-api-controllers.yml
@@ -1,7 +1,6 @@
 arches:
 - x86_64
 - aarch64
-mode: wip
 content:
   source:
     dockerfile: openshift/Dockerfile.openshift


### PR DESCRIPTION
build failed for aarch64, succeeded in all other arches: https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=44228086

ironically, my second build attempt (with limited arches) worked fine, building successfully for x86_64 _and_ aarch64: https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=44229794