### PR TITLE
[ART-3892] provide go 1.18 for 4.11

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -40,7 +40,8 @@ golang:
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-{MAJOR}.{MINOR}
 
 golang-1.18:
-  image: openshift/golang-builder@sha256:<wip>
+  # openshift-golang-builder-container-v1.18.1-1.scratch.nofips.g04fb1ce - an experimental build, YMMV
+  image: openshift/golang-builder@sha256:0f4c69877fe9e6b87ab0d6f70085d16f1fb1d523bf0aaa17cf3f84a7849fcc82
   mirror: true
   transform: rhel-8/golang
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-{MAJOR}.{MINOR}.art

--- a/streams.yml
+++ b/streams.yml
@@ -39,6 +39,19 @@ golang:
   # tests that don't happen downstream.
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-{MAJOR}.{MINOR}
 
+golang-1.18:
+  image: openshift/golang-builder@sha256:<wip>
+  mirror: true
+  transform: rhel-8/golang
+  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-{MAJOR}.{MINOR}.art
+  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-{MAJOR}.{MINOR}
+
+rhel-8-golang-1.18-ci-build-root:
+  image: not_applicable
+  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-{MAJOR}.{MINOR}
+  transform: rhel-8/ci-build-root
+  upstream_image: registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.18-openshift-{MAJOR}.{MINOR}
+
 # This is image is not used by ART. It is an artifact required in upstream CI to build unit tests.
 # Our transform is designed to create a buildconfig atop a specific golang version, layering on
 # packages that upstream has traditionally had present in its build_roots.


### PR DESCRIPTION
TODO
- [x] Create ocp-build-data branches
    - https://github.com/openshift/ocp-build-data/tree/golang-1.18/
    - https://github.com/openshift/ocp-build-data/tree/rhel-8-golang-1.18/
- [x] Gather scratch builds
    - [RHEL 8](https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=44278103)
    - [RHEL 7](https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=44278041)
- [x] Get repos with scratch builds
    - http://brew-task-repos.usersys.redhat.com/repos/scratch/dbenoit/golang/1.18+nofips.git.4aa1efed4853ea067d665a952eee77c52faac774/2.el8/
    - http://brew-task-repos.usersys.redhat.com/repos/scratch/dbenoit/golang/1.18+nofips.git.4aa1efed4853ea067d665a952eee77c52faac774/2.el7_9/
- [ ] Edit build configs appropriately
    - [x] rhel8 https://github.com/openshift/ocp-build-data/commit/04fb1ce91a9ff42cbc011fc836e6c79bafd36316
    - [ ] rhel7 https://github.com/openshift/ocp-build-data/pull/1485
- [ ] Build golang-builder using scratch repo
    - [x] rhel8: https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=44285203
    - [ ] rhel7: <>
- [ ] Include built golang builder images in this pr