### PR TITLE
Switch 4.11 to consume rhel-8.6 beta repos

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -181,78 +181,78 @@ repos:
   rhel-8-baseos-rpms:
     conf:
       baseurl:
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/aarch64/baseos/os/
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/
-        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/baseos/os/
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/aarch64/baseos/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/ppc64le/baseos/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/s390x/baseos/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/x86_64/baseos/os/
       ci_alignment:
         profiles:
         - el8
         localdev:
           enabled: true
     content_set:
-      default: rhel-8-for-x86_64-baseos-rpms
-      aarch64: rhel-8-for-aarch64-baseos-rpms
-      ppc64le: rhel-8-for-ppc64le-baseos-rpms
-      s390x: rhel-8-for-s390x-baseos-rpms
+      default: rhel-8-for-x86_64-baseos-beta-rpms
+      aarch64: rhel-8-for-aarch64-baseos-beta-rpms
+      ppc64le: rhel-8-for-ppc64le-baseos-beta-rpms
+      s390x: rhel-8-for-s390x-baseos-beta-rpms
     reposync:
       enabled: false
 
   rhel-8-codeready-builder-rpms:
     conf:
       baseurl:
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/aarch64/codeready-builder/os/
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/ppc64le/codeready-builder/os/
-        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/codeready-builder/os/
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/codeready-builder/os/
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/aarch64/codeready-builder/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/ppc64le/codeready-builder/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/s390x/codeready-builder/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/x86_64/codeready-builder/os/
       ci_alignment:
         profiles:
         - el8
         localdev:
           enabled: true
     content_set:
-      default: codeready-builder-for-rhel-8-x86_64-rpms
-      aarch64: codeready-builder-for-rhel-8-aarch64-rpms
-      ppc64le: codeready-builder-for-rhel-8-ppc64le-rpms
-      s390x: codeready-builder-for-rhel-8-s390x-rpms
+      default: codeready-builder-beta-for-rhel-8-x86_64-rpms
+      aarch64: codeready-builder-beta-for-rhel-8-aarch64-rpms
+      ppc64le: codeready-builder-beta-for-rhel-8-ppc64le-rpms
+      s390x: codeready-builder-beta-for-rhel-8-s390x-rpms
     reposync:
       enabled: false
 
   rhel-8-rt-rpms:
     conf:
       baseurl:
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/rt/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/x86_64/rt/os/
         # other arches don't exist, pointing at something that exists
-        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/rt/os/
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/rt/os/
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/rt/os/
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/x86_64/rt/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/x86_64/rt/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/x86_64/rt/os/
       ci_alignment:
         profiles:
         - el8
         localdev:
           enabled: true
     content_set:
-      default: rhel-8-for-x86_64-rt-rpms
+      default: rhel-8-for-x86_64-rt-beta-rpms
       # don't have content set for other arches
       optional: true
 
   rhel-8-appstream-rpms:
     conf:
       baseurl:
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/aarch64/appstream/os/
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/
-        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/appstream/os/
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/aarch64/appstream/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/ppc64le/appstream/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/s390x/appstream/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/x86_64/appstream/os/
       ci_alignment:
         profiles:
         - el8
         localdev:
           enabled: true
     content_set:
-      default: rhel-8-for-x86_64-appstream-rpms
-      aarch64: rhel-8-for-aarch64-appstream-rpms
-      ppc64le: rhel-8-for-ppc64le-appstream-rpms
-      s390x: rhel-8-for-s390x-appstream-rpms
+      default: rhel-8-for-x86_64-appstream-beta-rpms
+      aarch64: rhel-8-for-aarch64-appstream-beta-rpms
+      ppc64le: rhel-8-for-ppc64le-appstream-beta-rpms
+      s390x: rhel-8-for-s390x-appstream-beta-rpms
     reposync:
       enabled: false
 

--- a/streams.yml
+++ b/streams.yml
@@ -86,9 +86,9 @@ rhel-7-golang:
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-7-golang-1.17-openshift-{MAJOR}.{MINOR}
 
 rhel8:
-  # the most recent release at present. since we yum update this, maybe it does not need to float.
-  # but it is important that we not build from unreleased builds.
-  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi8:8.5-236
+  # the most recent release at present. since we yum update this, it does not need to float.
+  # it is important that we not build from unreleased builds and release them.
+  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi8:8.6-655
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-openshift-{MAJOR}.{MINOR}.art
   mirror: true
 


### PR DESCRIPTION
As rhcos seems to switch to 8.6-beta repos, we should probably follow suit.

There does not seem to be a released ubi8.6 beta image available, not sure if we should stick to released 8.5 based ubi, or if we should consume an unreleased image in this phase of 4.11 development?