### PR TITLE
WIP ART-3892 go1.18 for 4.11 rhel7

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -23,7 +23,7 @@
 # exclusively for testing are bundled on top of the golang builder image.
 rhel-7-ci-build-root:
   image: not_applicable
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-7-golang-1.17-openshift-{MAJOR}.{MINOR}
+  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-7-golang-1.18-openshift-{MAJOR}.{MINOR}?
   transform: rhel-7/ci-build-root
   upstream_image: registry.ci.openshift.org/openshift/release:rhel-7-release-openshift-{MAJOR}.{MINOR}
 
@@ -75,15 +75,15 @@ etcd_golang:
 
 # This image must only be used by -alt images, as this image cannot be built for aarch64.
 rhel-7-golang:
-  # openshift-golang-builder-container-v1.17.5-202202101345.el7.gf14244d
-  image: openshift/golang-builder@sha256:aaf215825b2ac2e2bd80095c13bae1997ff78bd5488f0ead904d2105d9538300
+  # openshift-golang-builder-container-v1.18.<wip>
+  image: openshift/golang-builder@sha256:<wip>
   mirror: true
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-7-golang-1.17-openshift-{MAJOR}.{MINOR}.art
+  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-7-golang-1.18-openshift-{MAJOR}.{MINOR}.art
   # dptp will layer yum repos / extra packages on top of ART's image to create the
   # actual upstream_image. This is to allow upstream some extra helpers to build
   # tests that don't happen downstream.
   transform: rhel-7/golang
-  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-7-golang-1.17-openshift-{MAJOR}.{MINOR}
+  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-7-golang-1.18-openshift-{MAJOR}.{MINOR}
 
 rhel8:
   # the most recent release at present. since we yum update this, maybe it does not need to float.


### PR DESCRIPTION
Following up from https://github.com/openshift/ocp-build-data/pull/1483

- [X] Create ocp-build-data branches
    - https://github.com/openshift/ocp-build-data/tree/golang-1.18/
- [X] Gather scratch builds
    - [RHEL 7](https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=44278041)
- [X] Get repos with scratch builds
    - http://brew-task-repos.usersys.redhat.com/repos/scratch/dbenoit/golang/1.18+nofips.git.4aa1efed4853ea067d665a952eee77c52faac774/2.el7_9/
- [ ] Edit build configs appropriately
    - rhel7 https://github.com/openshift/ocp-build-data/pull/1485
- [ ] Build golang-builder using scratch repo
    - rhel7: <>
- [ ] Include built golang builder images in this pr