### PR TITLE
Pin rhcos for amd64 until BZ 2072050 is fixed

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -14,6 +14,10 @@ releases:
         component: 'rhcos'
       - code: INCONSISTENT_RHCOS_RPMS
         component: 'rhcos'
+      rhcos:
+        machine-os-content:
+          images:
+            x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d1adb8ced0b692db72ed74f8f547d769ef319e10d8917cb8ae97bafbb717955f
   art3171:
     assembly:
       type: custom


### PR DESCRIPTION
We were requested to pin 411.85.202203242008-0 until https://bugzilla.redhat.com/show_bug.cgi?id=2072050 is fixed.