### PR TITLE
ose-baremetal-installer: provide GA libvirt

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -198,6 +198,48 @@ repos:
     reposync:
       enabled: false
 
+  # FIXME: these two -ga- repos are for ose-baremetal-installer which needs to
+  # remain pinned to a GA version of libvirt to match what users are most
+  # likely testing with - should be deleted once RHEL 8.6 is GA
+  rhel-8-ga-baseos-rpms:
+    conf:
+      baseurl:
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/aarch64/baseos/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/baseos/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/
+      ci_alignment:
+        profiles:
+        - el8
+        localdev:
+          enabled: true
+    content_set:
+      default: rhel-8-for-x86_64-baseos-rpms
+      aarch64: rhel-8-for-aarch64-baseos-rpms
+      ppc64le: rhel-8-for-ppc64le-baseos-rpms
+      s390x: rhel-8-for-s390x-baseos-rpms
+    reposync:
+      enabled: false
+  rhel-8-ga-appstream-rpms:
+    conf:
+      baseurl:
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/aarch64/appstream/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/appstream/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/
+      ci_alignment:
+        profiles:
+        - el8
+        localdev:
+          enabled: true
+    content_set:
+      default: rhel-8-for-x86_64-appstream-rpms
+      aarch64: rhel-8-for-aarch64-appstream-rpms
+      ppc64le: rhel-8-for-ppc64le-appstream-rpms
+      s390x: rhel-8-for-s390x-appstream-rpms
+    reposync:
+      enabled: false
+
   rhel-8-codeready-builder-rpms:
     conf:
       baseurl:

--- a/images/ose-baremetal-installer.yml
+++ b/images/ose-baremetal-installer.yml
@@ -18,6 +18,10 @@ enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
 - rhel-8-server-ose-rpms-embargoed
+# FIXME these two -ga- repos allow pinning a GA version of libvirt to match what
+# users are most likely testing with - should be deleted once RHEL 8.6 is GA
+- rhel-8-ga-baseos-rpms
+- rhel-8-ga-appstream-rpms
 for_payload: true
 from:
   builder:


### PR DESCRIPTION
The product builds for ose-baremetal-installer on 4.11 [started to fail](https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=44521601) since we changed the appstream repositories to rhel-8.6 beta content with `Error: Unable to find a match: libvirt-devel-6.0.0.`

libvirt is pinned to a GA version, and we need to keep that to interact with the libvirt most customers will be using until 8.6 is GA. So this enables GA repos to fit that need for now.