### PR TITLE
Pin rhcos for amd64 until BZ2077052 is fixed

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -14,6 +14,10 @@ releases:
         component: 'rhcos'
       - code: INCONSISTENT_RHCOS_RPMS
         component: 'rhcos'
+      rhcos:
+        machine-os-content:
+          images:
+            x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d1adb8ced0b692db72ed74f8f547d769ef319e10d8917cb8ae97bafbb717955f
   art3171:
     assembly:
       type: custom


### PR DESCRIPTION
This unreverts the pin for amd64, as the 8.6 bump has catastrophically
broken Azure.

This reverts commit 5b87660ab179f9c5d66f609752a4aaa08d2a0d4a.