### PR TITLE
Make ubi8 repos available in base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,8 @@ FROM rhel8
 RUN echo 'skip_missing_names_on_install=0' >> /etc/yum.conf \
  && yum update -y  \
  && yum clean all
+
+# ubi based images have the ubi repositories available. EUS / ELS images do not have their repositories
+# configured, and these repositories are not publicly accessible without an enabled subscription.
+# Making ubi8 repo available for all base images for the end user.
+COPY ubi.repo /etc/yum.repos.d/ubi8.repo

--- a/ubi.repo
+++ b/ubi.repo
@@ -1,0 +1,62 @@
+[ubi-8-baseos]
+name = Red Hat Universal Base Image 8 (RPMs) - BaseOS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-baseos-debug]
+name = Red Hat Universal Base Image 8 (Debug RPMs) - BaseOS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-baseos-source]
+name = Red Hat Universal Base Image 8 (Source RPMs) - BaseOS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-appstream]
+name = Red Hat Universal Base Image 8 (RPMs) - AppStream
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/appstream/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-appstream-debug]
+name = Red Hat Universal Base Image 8 (Debug RPMs) - AppStream
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/appstream/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-appstream-source]
+name = Red Hat Universal Base Image 8 (Source RPMs) - AppStream
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-codeready-builder]
+name = Red Hat Universal Base Image 8 (RPMs) - CodeReady Builder
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/codeready-builder/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-codeready-builder-debug]
+name = Red Hat Universal Base Image 8 (Debug RPMs) - CodeReady Builder
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/codeready-builder/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-8-codeready-builder-source]
+name = Red Hat Universal Base Image 8 (Source RPMs) - CodeReady Builder
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1


### PR DESCRIPTION
ubi based images have the ubi repositories available. EUS / ELS images do not have their repositories
configured, and these repositories are not publicly accessible without an enabled subscription.

Losing these repositories is a regression for at least ansible-operator.

This commit makes ubi8 repo available for all base images for the end user (they
are disabled during the osbs build, and get patched in again afterwards,
so it does not interfere with product builds).