### PR TITLE
Revert "openshift RPM: no longer supporting RHEL7 workers"

### DIFF
--- a/rpms/openshift.yml
+++ b/rpms/openshift.yml
@@ -14,3 +14,11 @@ name: openshift
 owners:
 - aos-master@redhat.com
 - ccoleman@redhat.com
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-7
+targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-7-candidate  # this is needed for RHEL 7 worker node support
+- rhaos-{MAJOR}.{MINOR}-rhel-8-candidate
+hotfix_targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-7-hotfix  # this is needed for RHEL 7 worker node support
+- rhaos-{MAJOR}.{MINOR}-rhel-8-hotfix


### PR DESCRIPTION
Reverts openshift/ocp-build-data#1531

Branch rhaos-4.11-rhel-8 does not exist yet in distgit. Reverting for now.