### PR TITLE
ose-libvirt-machine-controllers: enable CI alignment labels

### DIFF
--- a/images/ose-libvirt-machine-controllers.yml
+++ b/images/ose-libvirt-machine-controllers.yml
@@ -8,6 +8,12 @@ content:
       web: https://github.com/openshift/cluster-api-provider-libvirt
     ci_alignment:
       streams_prs:
+        auto_label:  # Enable PR merging as quickly as possible by pre-approving it.
+        - lgtm
+        - approved
+        - backport-risk-assessed
+        - bugzilla/valid-bug
+        - cherry-pick-approved
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
 enabled_repos:


### PR DESCRIPTION
ref https://coreos.slack.com/archives/CB95J6R4N/p1650895691230349?thread_ts=1650637363.040359&cid=CB95J6R4N