### PR TITLE
Revert "Revert "openshift RPM: no longer supporting RHEL7 workers""

### DIFF
--- a/rpms/openshift.yml
+++ b/rpms/openshift.yml
@@ -14,11 +14,3 @@ name: openshift
 owners:
 - aos-master@redhat.com
 - ccoleman@redhat.com
-distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-7
-targets:
-- rhaos-{MAJOR}.{MINOR}-rhel-7-candidate  # this is needed for RHEL 7 worker node support
-- rhaos-{MAJOR}.{MINOR}-rhel-8-candidate
-hotfix_targets:
-- rhaos-{MAJOR}.{MINOR}-rhel-7-hotfix  # this is needed for RHEL 7 worker node support
-- rhaos-{MAJOR}.{MINOR}-rhel-8-hotfix


### PR DESCRIPTION
should be ready for this now that https://issues.redhat.com/browse/CLOUDBLD-9878 is complete.