### PR TITLE
Revert "Pin rhcos for amd64 until BZ2077052 is fixed"

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -14,10 +14,6 @@ releases:
         component: 'rhcos'
       - code: INCONSISTENT_RHCOS_RPMS
         component: 'rhcos'
-      rhcos:
-        machine-os-content:
-          images:
-            x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d1adb8ced0b692db72ed74f8f547d769ef319e10d8917cb8ae97bafbb717955f
   art3171:
     assembly:
       type: custom


### PR DESCRIPTION
RHCOS builds using RHEL 8.6 content and NetworkManager 1.32.10-4.el8
(from RHEL 8.5) have been successfully produced and tested in Azure
(where https://bugzilla.redhat.com/show_bug.cgi?id=2077052 ->
https://bugzilla.redhat.com/show_bug.cgi?id=2077605) was observed.

Let's try using the 8.6 content yet again.

This reverts commit 516e23d7538dfa2ff8ddff60a012005ced101bf8.