### PR TITLE
Revert "Bug 2081062: Revert "Revert "Pin rhcos for amd64 until BZ2077052 is fixed"""

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -14,10 +14,6 @@ releases:
         component: 'rhcos'
       - code: INCONSISTENT_RHCOS_RPMS
         component: 'rhcos'
-      rhcos:
-        machine-os-content:
-          images:
-            x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d1adb8ced0b692db72ed74f8f547d769ef319e10d8917cb8ae97bafbb717955f
   art3171:
     assembly:
       type: custom


### PR DESCRIPTION
Reverts openshift/ocp-build-data#1552

This is being reverted in preference of changing RHCOS 4.11 over to consume 8.5 bits.