### PR TITLE
Migrate to RHEL 8.6 EUS content and base image

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -181,120 +181,78 @@ repos:
   rhel-8-baseos-rpms:
     conf:
       baseurl:
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/aarch64/baseos/os/
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/ppc64le/baseos/os/
-        s390x: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/s390x/baseos/os/
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/x86_64/baseos/os/
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/aarch64/baseos/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/ppc64le/baseos/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/s390x/baseos/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/x86_64/baseos/os/
       ci_alignment:
         profiles:
         - el8
         localdev:
           enabled: true
     content_set:
-      default: rhel-8-for-x86_64-baseos-beta-rpms
-      aarch64: rhel-8-for-aarch64-baseos-beta-rpms
-      ppc64le: rhel-8-for-ppc64le-baseos-beta-rpms
-      s390x: rhel-8-for-s390x-baseos-beta-rpms
-    reposync:
-      enabled: false
-
-  # FIXME: these two -ga- repos are for ose-baremetal-installer which needs to
-  # remain pinned to a GA version of libvirt to match what users are most
-  # likely testing with - should be deleted once RHEL 8.6 is GA
-  rhel-8-ga-baseos-rpms:
-    conf:
-      baseurl:
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/aarch64/baseos/os/
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/
-        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/baseos/os/
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/
-      ci_alignment:
-        profiles:
-        - el8
-        localdev:
-          enabled: true
-    content_set:
-      default: rhel-8-for-x86_64-baseos-rpms
-      aarch64: rhel-8-for-aarch64-baseos-rpms
-      ppc64le: rhel-8-for-ppc64le-baseos-rpms
-      s390x: rhel-8-for-s390x-baseos-rpms
-    reposync:
-      enabled: false
-  rhel-8-ga-appstream-rpms:
-    conf:
-      baseurl:
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/aarch64/appstream/os/
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/
-        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/appstream/os/
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/
-      ci_alignment:
-        profiles:
-        - el8
-        localdev:
-          enabled: true
-    content_set:
-      default: rhel-8-for-x86_64-appstream-rpms
-      aarch64: rhel-8-for-aarch64-appstream-rpms
-      ppc64le: rhel-8-for-ppc64le-appstream-rpms
-      s390x: rhel-8-for-s390x-appstream-rpms
+      default: rhel-8-for-x86_64-baseos-eus-rpms__8_DOT_6
+      aarch64: rhel-8-for-aarch64-baseos-eus-rpms__8_DOT_6
+      ppc64le: rhel-8-for-ppc64le-baseos-eus-rpms__8_DOT_6
+      s390x: rhel-8-for-s390x-baseos-eus-rpms__8_DOT_6
     reposync:
       enabled: false
 
   rhel-8-codeready-builder-rpms:
     conf:
       baseurl:
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/aarch64/codeready-builder/os/
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/ppc64le/codeready-builder/os/
-        s390x: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/s390x/codeready-builder/os/
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/x86_64/codeready-builder/os/
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/aarch64/codeready-builder/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/ppc64le/codeready-builder/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/s390x/codeready-builder/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/x86_64/codeready-builder/os/
       ci_alignment:
         profiles:
         - el8
         localdev:
           enabled: true
     content_set:
-      default: codeready-builder-beta-for-rhel-8-x86_64-rpms
-      aarch64: codeready-builder-beta-for-rhel-8-aarch64-rpms
-      ppc64le: codeready-builder-beta-for-rhel-8-ppc64le-rpms
-      s390x: codeready-builder-beta-for-rhel-8-s390x-rpms
+      default: codeready-builder-for-rhel-8-x86_64-eus-rpms__8_DOT_6
+      aarch64: codeready-builder-for-rhel-8-aarch64-eus-rpms__8_DOT_6
+      ppc64le: codeready-builder-for-rhel-8-ppc64le-eus-rpms__8_DOT_6
+      s390x: codeready-builder-for-rhel-8-s390x-eus-rpms__8_DOT_6
     reposync:
       enabled: false
 
   rhel-8-rt-rpms:
     conf:
       baseurl:
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/x86_64/rt/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/tus/rhel8/8.6/x86_64/rt/os/
         # other arches don't exist, pointing at something that exists
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/x86_64/rt/os/
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/x86_64/rt/os/
-        s390x: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/x86_64/rt/os/
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/tus/rhel8/8.6/x86_64/rt/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/tus/rhel8/8.6/x86_64/rt/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/tus/rhel8/8.6/x86_64/rt/os/
       ci_alignment:
         profiles:
         - el8
         localdev:
           enabled: true
     content_set:
-      default: rhel-8-for-x86_64-rt-beta-rpms
+      default: rhel-8-for-x86_64-rt-tus-rpms__8_DOT_6
       # don't have content set for other arches
       optional: true
 
   rhel-8-appstream-rpms:
     conf:
       baseurl:
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/aarch64/appstream/os/
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/ppc64le/appstream/os/
-        s390x: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/s390x/appstream/os/
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/beta/rhel8/8/x86_64/appstream/os/
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/aarch64/appstream/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/ppc64le/appstream/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/s390x/appstream/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/x86_64/appstream/os/
       ci_alignment:
         profiles:
         - el8
         localdev:
           enabled: true
     content_set:
-      default: rhel-8-for-x86_64-appstream-beta-rpms
-      aarch64: rhel-8-for-aarch64-appstream-beta-rpms
-      ppc64le: rhel-8-for-ppc64le-appstream-beta-rpms
-      s390x: rhel-8-for-s390x-appstream-beta-rpms
+      default: rhel-8-for-x86_64-appstream-eus-rpms__8_DOT_6
+      aarch64: rhel-8-for-aarch64-appstream-eus-rpms__8_DOT_6
+      ppc64le: rhel-8-for-ppc64le-appstream-eus-rpms__8_DOT_6
+      s390x: rhel-8-for-s390x-appstream-eus-rpms__8_DOT_6
     reposync:
       enabled: false
 

--- a/images/ose-baremetal-installer.yml
+++ b/images/ose-baremetal-installer.yml
@@ -18,10 +18,6 @@ enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
 - rhel-8-server-ose-rpms-embargoed
-# FIXME these two -ga- repos allow pinning a GA version of libvirt to match what
-# users are most likely testing with - should be deleted once RHEL 8.6 is GA
-- rhel-8-ga-baseos-rpms
-- rhel-8-ga-appstream-rpms
 for_payload: true
 from:
   builder:

--- a/streams.yml
+++ b/streams.yml
@@ -88,7 +88,7 @@ rhel-7-golang:
 rhel8:
   # the most recent release at present. since we yum update this, it does not need to float.
   # it is important that we not build from unreleased builds and release them.
-  image: registry-proxy.engineering.redhat.com/rh-osbs/rhel-els:8.6-744
+  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi8:8.6-754
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-openshift-{MAJOR}.{MINOR}.art
   mirror: true
 

--- a/streams.yml
+++ b/streams.yml
@@ -88,7 +88,7 @@ rhel-7-golang:
 rhel8:
   # the most recent release at present. since we yum update this, it does not need to float.
   # it is important that we not build from unreleased builds and release them.
-  image: registry-proxy.engineering.redhat.com/rh-osbs/ubi8:8.6-655
+  image: registry-proxy.engineering.redhat.com/rh-osbs/rhel-els:8.6-744
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-openshift-{MAJOR}.{MINOR}.art
   mirror: true
 


### PR DESCRIPTION
- Migrate content to RHEL 8.6 EUS
- Update base image to rhel-els 8.6 GA equivalent

