### PR TITLE
[ART-4013] Revert "Set WIP mode for Shared Resource CSI Driver Webhook"

### DIFF
--- a/images/ose-csi-driver-shared-resource-webhook.yml
+++ b/images/ose-csi-driver-shared-resource-webhook.yml
@@ -1,4 +1,3 @@
-mode: wip
 content:
   source:
     dockerfile: Dockerfile.webhook


### PR DESCRIPTION
This is needed to unbreak the payloads (see https://github.com/openshift/cluster-storage-operator/pull/285)

This reverts commit 19886920c843c430217b07c6710fc6a03a8ff872.

/cc @thiagoalessio @locriandev
