### PR TITLE
[ART-4013] Fix payload name of csi-driver-shared-resource-webhook

### DIFF
--- a/images/ose-csi-driver-shared-resource-webhook.yml
+++ b/images/ose-csi-driver-shared-resource-webhook.yml
@@ -17,6 +17,6 @@ from:
   builder:
   - stream: golang
   member: openshift-enterprise-base
-name: openshift/ose-csi-driver-shared-resource-webhook-rhel
+name: openshift/ose-csi-driver-shared-resource-webhook
 owners:
 - openshift-build-jenkins-team@redhat.com


### PR DESCRIPTION
This was a mistake in #1586 that is breaking payload generation.
