### PR TITLE
[ART-4013] Add csi-driver-shared-resource-webhook to payload

### DIFF
--- a/images/ose-csi-driver-shared-resource-webhook.yml
+++ b/images/ose-csi-driver-shared-resource-webhook.yml
@@ -12,7 +12,7 @@ content:
           stream: rhel-8-golang-ci-build-root
 distgit:
   component: ose-csi-driver-shared-resource-webhook-container
-for_payload: false
+for_payload: true
 from:
   builder:
   - stream: golang


### PR DESCRIPTION
This is necessary as the cluster-storage-operator will reference it: https://github.com/openshift/cluster-storage-operator/pull/278
