### PR TITLE
4.11 - Remove redundant permits from releases.yml

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -8,10 +8,6 @@ releases:
         component: '*'
       - code: OUTDATED_RPMS_IN_STREAM_BUILD
         component: 'rhcos'
-      - code: CONFLICTING_GROUP_RPM_INSTALLED
-        component: 'rhcos'
-      - code: INCONSISTENT_RHCOS_RPMS
-        component: 'rhcos'
   art3171:
     assembly:
       type: custom

--- a/releases.yml
+++ b/releases.yml
@@ -4,8 +4,6 @@ releases:
       type: stream
       permits:
       # why: "Always build shippable" does not apply while we're setting up 4.11
-      - code: MISMATCHED_SIBLINGS
-        component: '*'
       - code: OUTDATED_RPMS_IN_STREAM_BUILD
         component: '*'
       - code: OUTDATED_RPMS_IN_STREAM_BUILD


### PR DESCRIPTION
Test [build-sync](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fbuild-sync/24355/console)