### PR TITLE
4.11: driver-toolkit tracks rhel-8.5

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -198,6 +198,26 @@ repos:
     reposync:
       enabled: false
 
+  rhel-85-baseos-rpms:
+    conf:
+      baseurl:
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.5/aarch64/baseos/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.5/ppc64le/baseos/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.5/s390x/baseos/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.5/x86_64/baseos/os/
+      ci_alignment:
+        profiles:
+        - el8
+        localdev:
+          enabled: false
+    content_set:
+      default: rhel-8-for-x86_64-baseos-rpms__8_DOT_5
+      aarch64: rhel-8-for-aarch64-baseos-rpms__8_DOT_5
+      ppc64le: rhel-8-for-ppc64le-baseos-rpms__8_DOT_5
+      s390x: rhel-8-for-s390x-baseos-rpms__8_DOT_5
+    reposync:
+      enabled: false
+
   rhel-8-codeready-builder-rpms:
     conf:
       baseurl:
@@ -221,18 +241,18 @@ repos:
   rhel-8-rt-rpms:
     conf:
       baseurl:
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/tus/rhel8/8.6/x86_64/rt/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.5/x86_64/rt/os/
         # other arches don't exist, pointing at something that exists
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/tus/rhel8/8.6/x86_64/rt/os/
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/tus/rhel8/8.6/x86_64/rt/os/
-        s390x: http://rhsm-pulp.corp.redhat.com/content/tus/rhel8/8.6/x86_64/rt/os/
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.5/x86_64/rt/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.5/x86_64/rt/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.5/x86_64/rt/os/
       ci_alignment:
         profiles:
         - el8
         localdev:
           enabled: true
     content_set:
-      default: rhel-8-for-x86_64-rt-tus-rpms__8_DOT_6
+      default: rhel-8-for-x86_64-rt-rpms__8_DOT_5
       # don't have content set for other arches
       optional: true
 
@@ -253,6 +273,26 @@ repos:
       aarch64: rhel-8-for-aarch64-appstream-eus-rpms__8_DOT_6
       ppc64le: rhel-8-for-ppc64le-appstream-eus-rpms__8_DOT_6
       s390x: rhel-8-for-s390x-appstream-eus-rpms__8_DOT_6
+    reposync:
+      enabled: false
+
+  rhel-85-appstream-rpms:
+    conf:
+      baseurl:
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.5/aarch64/appstream/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.5/ppc64le/appstream/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.5/s390x/appstream/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.5/x86_64/appstream/os/
+      ci_alignment:
+        profiles:
+        - el8
+        localdev:
+          enabled: false
+    content_set:
+      default: rhel-8-for-x86_64-appstream-rpms__8_DOT_5
+      aarch64: rhel-8-for-aarch64-appstream-rpms__8_DOT_5
+      ppc64le: rhel-8-for-ppc64le-appstream-rpms__8_DOT_5
+      s390x: rhel-8-for-s390x-appstream-rpms__8_DOT_5
     reposync:
       enabled: false
 

--- a/images/driver-toolkit.yml
+++ b/images/driver-toolkit.yml
@@ -21,9 +21,9 @@ content:
       url: git@github.com:openshift-priv/driver-toolkit.git
       web: https://github.com/openshift/driver-toolkit
 enabled_repos:
-- rhel-8-baseos-rpms
+- rhel-85-baseos-rpms
 - rhel-8-rt-rpms
-- rhel-8-appstream-rpms
+- rhel-85-appstream-rpms
 for_payload: true
 from:
   member: openshift-enterprise-base


### PR DESCRIPTION
...until rhcos is able to switch to 8.6 again