### PR TITLE
[4.11] remove rhel7 rpms

### DIFF
--- a/rpms/openshift-ansible.yml
+++ b/rpms/openshift-ansible.yml
@@ -9,11 +9,3 @@ name: openshift-ansible
 owners:
 - rteague@redhat.com
 - sdodson@redhat.com
-distgit:
-  # this is needed for RHEL 7 worker node support
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-7
-targets:
-- rhaos-{MAJOR}.{MINOR}-rhel-7-candidate  # this is needed for RHEL 7 worker node support
-hotfix_targets:
-- rhaos-{MAJOR}.{MINOR}-rhel-7-hotfix  # this is needed for RHEL 7 worker node support
-

--- a/rpms/openshift-clients.yml
+++ b/rpms/openshift-clients.yml
@@ -8,11 +8,3 @@ content:
 name: openshift-clients
 owners:
 - aos-master@redhat.com
-distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-7
-targets:
-- rhaos-{MAJOR}.{MINOR}-rhel-7-candidate  # this is needed for RHEL 7 worker node support
-- rhaos-{MAJOR}.{MINOR}-rhel-8-candidate
-hotfix_targets:
-- rhaos-{MAJOR}.{MINOR}-rhel-7-hotfix  # this is needed for RHEL 7 worker node support
-- rhaos-{MAJOR}.{MINOR}-rhel-8-hotfix


### PR DESCRIPTION
Follow up on https://github.com/openshift/ocp-build-data/pull/1584
Can stop using rhel7 branches once https://issues.redhat.com/browse/CLOUDBLD-10065 gives us a rhel8 branch.