### PR TITLE
ose-machine-os-images: Don't reconcile build_root_image

### DIFF
--- a/images/ose-machine-os-images.yml
+++ b/images/ose-machine-os-images.yml
@@ -8,10 +8,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/machine-os-images.git
       web: https://github.com/openshift/machine-os-images
-    ci_alignment:
-      streams_prs:
-        ci_build_root:
-          stream: rhel-8-golang-ci-build-root
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms


### PR DESCRIPTION
ose-machine-os-images uses its own shellcheck image and doesn't use golang.