### PR TITLE
Build installer-artifacts with golang 1.18

### DIFF
--- a/images/ose-installer-artifacts.yml
+++ b/images/ose-installer-artifacts.yml
@@ -13,16 +13,16 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-1.17-ci-build-root
+          stream: rhel-8-golang-ci-build-root
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
 for_payload: true
 from:
   builder:
-  - stream: golang-1.17
-  - stream: golang-1.17
-  - stream: golang-1.17
+  - stream: golang
+  - stream: golang
+  - stream: golang
   member: ose-installer
 name: openshift/ose-installer-artifacts
 owners:

--- a/streams.yml
+++ b/streams.yml
@@ -28,17 +28,6 @@ golang:
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-{MAJOR}.{MINOR}.art
   upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-{MAJOR}.{MINOR}
 
-golang-1.17:
-  # openshift-golang-builder-container-v1.17.5-202202101345.el8.gb1a57e0
-  image: openshift/golang-builder@sha256:4820580c3368f320581eb9e32cf97aeec179a86c5749753a14ed76410a293d83
-  mirror: true
-  transform: rhel-8/golang
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-{MAJOR}.{MINOR}.art
-  # dptp will layer yum repos / extra packages on top of ART's image to create the
-  # actual upstream_image. This is to allow upstream some extra helpers to build
-  # tests that don't happen downstream.
-  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-{MAJOR}.{MINOR}
-
 # This is image is not used by ART. It is an artifact required in upstream CI to build unit tests.
 # Our transform is designed to create a buildconfig atop a specific golang version, layering on
 # packages that upstream has traditionally had present in its build_roots.
@@ -47,12 +36,6 @@ rhel-8-golang-ci-build-root:
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-{MAJOR}.{MINOR}
   transform: rhel-8/ci-build-root
   upstream_image: registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.18-openshift-{MAJOR}.{MINOR}
-
-rhel-8-golang-1.17-ci-build-root:
-  image: not_applicable
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-{MAJOR}.{MINOR}
-  transform: rhel-8/ci-build-root
-  upstream_image: registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.17-openshift-{MAJOR}.{MINOR}
 
 
 # IMPORTANT: etcd has unique approval to track its own etcd version. Other repos need arch


### PR DESCRIPTION
The compile issue with 1.18 for darwin targets should be fixed by https://github.com/openshift/installer/pull/5896

/cc @locriandev
