### PR TITLE
Revert "4.11 - Remove redundant permits from releases.yml"

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -4,9 +4,15 @@ releases:
       type: stream
       permits:
       # why: "Always build shippable" does not apply while we're setting up 4.11
+      - code: MISMATCHED_SIBLINGS
+        component: '*'
       - code: OUTDATED_RPMS_IN_STREAM_BUILD
         component: '*'
       - code: OUTDATED_RPMS_IN_STREAM_BUILD
+        component: 'rhcos'
+      - code: CONFLICTING_GROUP_RPM_INSTALLED
+        component: 'rhcos'
+      - code: INCONSISTENT_RHCOS_RPMS
         component: 'rhcos'
   art3171:
     assembly:


### PR DESCRIPTION
Reverts openshift/ocp-build-data#1609

RHCOS builds for ppc64le are failing and this is preventing TRT from getting new 4.11 nightlies. This should be re-reverted once p8 RHCOS builds resume flowing.