### PR TITLE
Add ironic tag to product version mapping

### DIFF
--- a/erratatool.yml
+++ b/erratatool.yml
@@ -6,10 +6,11 @@ product: "RHOSE"
 release: "RHOSE ASYNC"
 
 brew_tag_product_version_mapping:
-  rhaos-{MAJOR}.{MINOR}-rhel-7-candidate: RHEL-7-OSE-{MAJOR}.{MINOR}
   rhaos-{MAJOR}.{MINOR}-rhel-8-candidate: OSE-{MAJOR}.{MINOR}-RHEL-8
-  rhaos-{MAJOR}.{MINOR}-rhel-7-hotfix: RHEL-7-OSE-{MAJOR}.{MINOR}
   rhaos-{MAJOR}.{MINOR}-rhel-8-hotfix: OSE-{MAJOR}.{MINOR}-RHEL-8
+  rhaos-{MAJOR}.{MINOR}-ironic-rhel-8-candidate: OSE-IRONIC-{MAJOR}.{MINOR}-RHEL-8
+  # There is no hotfix tag
+  # rhaos-{MAJOR}.{MINOR}-ironic-rhel-8-hotfix: OSE-IRONIC-{MAJOR}.{MINOR}-RHEL-8
 
 cdn_repos:
 - rhocp-{MAJOR}_DOT_{MINOR}-for-rhel-8-x86_64-rpms


### PR DESCRIPTION
...and stop to look at rhel-7 tags.

```
⫸  elliott -g openshift-4.11 --data-path $(pwd) find-builds -k rpm
2022-06-03 12:05:25,239 INFO Using branch from group.yml: rhaos-4.11-rhel-8
Generating list of rpms: Hold on a moment, fetching Brew builds
2022-06-03 12:05:29,628 INFO Finding builds specific to assembly stream in Brew tag rhaos-4.11-rhel-8-candidate...
2022-06-03 12:05:32,689 INFO Found 83 builds.
2022-06-03 12:05:32,689 INFO Finding builds specific to assembly stream in Brew tag rhaos-4.11-rhel-8-hotfix...
2022-06-03 12:05:32,935 INFO Found 5 builds.
2022-06-03 12:05:32,936 INFO Finding builds specific to assembly stream in Brew tag rhaos-4.11-ironic-rhel-8-candidate...
2022-06-03 12:05:34,220 INFO Found 122 builds.
```