### PR TITLE
Re-revert "4.11 - Remove redundant permits from releases.yml"

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -35,10 +35,6 @@ releases:
         component: '*'
       - code: OUTDATED_RPMS_IN_STREAM_BUILD
         component: 'rhcos'
-      - code: CONFLICTING_GROUP_RPM_INSTALLED
-        component: 'rhcos'
-      - code: INCONSISTENT_RHCOS_RPMS
-        component: 'rhcos'
   art3171:
     assembly:
       type: custom

--- a/releases.yml
+++ b/releases.yml
@@ -31,8 +31,6 @@ releases:
       type: stream
       permits:
       # why: "Always build shippable" does not apply while we're setting up 4.11
-      - code: MISMATCHED_SIBLINGS
-        component: '*'
       - code: OUTDATED_RPMS_IN_STREAM_BUILD
         component: '*'
       - code: OUTDATED_RPMS_IN_STREAM_BUILD


### PR DESCRIPTION
[p8 RHCOS builds](https://jenkins-rhcos.cloud.p8.psi.redhat.com/job/rhcos/job/rhcos-rhcos-4.11/) seem to be back

Ref. https://github.com/openshift/ocp-build-data/pull/1654