### PR TITLE
Fix bundle dir for vertical-pod-autoscaler-operator

### DIFF
--- a/images/vertical-pod-autoscaler-operator.yml
+++ b/images/vertical-pod-autoscaler-operator.yml
@@ -26,6 +26,6 @@ name: openshift/ose-vertical-pod-autoscaler-rhel8-operator
 owners:
 - joesmith@redhat.com
 update-csv:
-  bundle-dir: '{MAJOR}.x/'
+  bundle-dir: '{MAJOR}.{MINOR}/'
   manifests-dir: manifests/
   registry: image-registry.openshift-image-registry.svc:5000


### PR DESCRIPTION
This fixes this error:

`doozerlib.exceptions.DoozerFatalError: vertical-pod-autoscaler-operator: did not find a *.clusterserviceversion.yaml file @ /mnt/workspace/jenkins/working/aos-cd-builds/build%2Focp4/doozer_working/distgits/containers/vertical-pod-autoscaler-operator/manifests/4.x/`

that was breaking builds after https://github.com/openshift/vertical-pod-autoscaler-operator/pull/126 merged.

Test build: https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2040170
Jenkins job: https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Focp4/28690/consoleFull