### PR TITLE
pin to last good x86_64 machine-os-content

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -28,6 +28,10 @@ releases:
       type: candidate
   stream:
     assembly:
+      rhcos:
+        machine-os-content:
+          images:
+            x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:471331824d00c9e44983b74abf1ecef94ebb312897c426d7645df656dc7449f0
       type: stream
       permits:
       # why: "Always build shippable" does not apply while we're setting up 4.11


### PR DESCRIPTION
The most recent `machine-os-content` introduced a newer version of
`conmon` that catastrophically broke all of the e2e jobs.

We want to pin to the last known good RHCOS 4.11 image in the release
payload while `conmon` is fixed to allow for other changes in OCP to
land.

Last known good payload - https://amd64.ocp.releases.ci.openshift.org/releasestream/4.11.0-0.nightly/release/4.11.0-0.nightly-2022-06-06-025509