### PR TITLE
pin to last known good `machine-os-content` on all arches

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -31,6 +31,9 @@ releases:
       rhcos:
         machine-os-content:
           images:
+            aarch64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:71738f87fcb4fbdde7e173e9d5ea35d6d5c995555971ed8c4a821f99f5968150
+            ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:e51784e913b6f57ce6e7005ba88b1d5e3e7ea46dbc71764e87f93fabd513c5e1
+            s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:06e691588540fa592c6387ead80cffe8d69077b25b2a8b370a8542c0279e2d9a
             x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:471331824d00c9e44983b74abf1ecef94ebb312897c426d7645df656dc7449f0
       type: stream
       permits:


### PR DESCRIPTION
Follow-up to #1667

Last known good payloads:

aarch64 -https://arm64.ocp.releases.ci.openshift.org/releasestream/4.11.0-0.nightly-arm64/release/4.11.0-0.nightly-arm64-2022-06-06-221738
ppc64le - https://ppc64le.ocp.releases.ci.openshift.org/releasestream/4.11.0-0.nightly-ppc64le/release/4.11.0-0.nightly-ppc64le-2022-06-06-200749
s390x - https://s390x.ocp.releases.ci.openshift.org/releasestream/4.11.0-0.nightly-s390x/release/4.11.0-0.nightly-s390x-2022-06-06-184601

See: https://coreos.slack.com/archives/C039RDU7DB9/p1654600783329319?thread_ts=1654537919.135249&cid=C039RDU7DB9