### PR TITLE
releases.yml: init 4.9.38 definition

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -1,4 +1,35 @@
 releases:
+  4.9.38:
+    assembly:
+      basis:
+        brew_event: 45845509
+        #reference_releases: but with machine-os-content overridden
+        # aarch64: 4.9.0-0.nightly-arm64-2022-06-08-093744
+        # ppc64le: 4.9.0-0.nightly-ppc64le-2022-06-08-093607
+        # s390x: 4.9.0-0.nightly-s390x-2022-06-08-093658
+        # x86_64: 4.9.0-0.nightly-2022-06-08-150705
+      group:
+        advisories:
+          extras: -1
+          image: -1
+          metadata: -1
+          rpm: -1
+        upgrades: 4.8.14,4.8.15,4.8.16,4.8.17,4.8.18,4.8.19,4.8.20,4.8.21,4.8.22,4.8.23,4.8.24,4.8.25,4.8.26,4.8.27,4.8.28,4.8.29,4.8.30,4.8.31,4.8.32,4.8.33,4.8.34,4.8.35,4.8.36,4.8.37,4.8.38,4.8.39,4.8.40,4.8.41,4.8.42,4.8.43,4.9.0,4.9.1,4.9.4,4.9.5,4.9.6,4.9.7,4.9.8,4.9.9,4.9.10,4.9.11,4.9.12,4.9.13,4.9.15,4.9.17,4.9.18,4.9.19,4.9.21,4.9.22,4.9.23,4.9.24,4.9.25,4.9.26,4.9.27,4.9.28,4.9.29,4.9.30,4.9.31,4.9.32,4.9.33,4.9.34,4.9.35,4.9.36,4.9.37
+      members:
+        images: []
+        rpms: []
+      rhcos:
+        machine-os-content:
+          images:
+            # custom 49.84.202206082141-0
+            aarch64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:088e2d1c8e7648a58c0674c8451ea95719aac86cd0d52633fca2f1ae5de195e3
+            # custom 49.84.202206080838-0
+            ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:32eda7deb5d0332ac2270d99b1858e956fa43c8cba1f3581419841e5613dfe35
+            # custom 49.84.202206080504-0
+            s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ca8eecbb45d9279bb645545bc95238b46ce7aa8546c12dd75c8e393f86a611ff
+            # custom 49.84.202206082248-0
+            x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:61f3e7f7daa8008b671112f53f19cec534382c415fbb3d4717cbbf6b932078e9
+      type: standard
   4.9.37:
     assembly:
       basis:


### PR DESCRIPTION
4.9.38 assembly with custom RHCOS builds penciled in for later. should be able to prepare the release ASAP while waiting for those builds to complete.