### PR TITLE
[openshift-4.11] Drop s390x builds of PTP and SR-IOV operator images

### DIFF
--- a/images/cloud-event-proxy.yml
+++ b/images/cloud-event-proxy.yml
@@ -1,3 +1,7 @@
+arches:
+- x86_64
+- aarch64
+- ppc64le
 content:
   source:
     git:

--- a/images/ib-sriov-cni.yml
+++ b/images/ib-sriov-cni.yml
@@ -1,3 +1,7 @@
+arches:
+- x86_64
+- aarch64
+- ppc64le
 content:
   source:
     dockerfile: Dockerfile.rhel7

--- a/images/linuxptp-daemon.yml
+++ b/images/linuxptp-daemon.yml
@@ -1,3 +1,7 @@
+arches:
+- x86_64
+- aarch64
+- ppc64le
 content:
   source:
     dockerfile: Dockerfile.rhel7

--- a/images/ptp-operator-must-gather.yml
+++ b/images/ptp-operator-must-gather.yml
@@ -1,3 +1,7 @@
+arches:
+- x86_64
+- aarch64
+- ppc64le
 content:
   source:
     dockerfile: Dockerfile.rhel7

--- a/images/ptp-operator.yml
+++ b/images/ptp-operator.yml
@@ -1,3 +1,7 @@
+arches:
+- x86_64
+- aarch64
+- ppc64le
 content:
   source:
     dockerfile: Dockerfile.rhel7

--- a/images/sriov-cni.yml
+++ b/images/sriov-cni.yml
@@ -1,3 +1,7 @@
+arches:
+- x86_64
+- aarch64
+- ppc64le
 content:
   source:
     dockerfile: Dockerfile.rhel7

--- a/images/sriov-dp-admission-controller.yml
+++ b/images/sriov-dp-admission-controller.yml
@@ -1,3 +1,7 @@
+arches:
+- x86_64
+- aarch64
+- ppc64le
 content:
   source:
     dockerfile: Dockerfile.rhel7

--- a/images/sriov-network-config-daemon.yml
+++ b/images/sriov-network-config-daemon.yml
@@ -1,3 +1,7 @@
+arches:
+- x86_64
+- aarch64
+- ppc64le
 content:
   source:
     dockerfile: Dockerfile.sriov-network-config-daemon.rhel7

--- a/images/sriov-network-device-plugin.yml
+++ b/images/sriov-network-device-plugin.yml
@@ -1,3 +1,7 @@
+arches:
+- x86_64
+- aarch64
+- ppc64le
 content:
   source:
     dockerfile: Dockerfile.rhel7

--- a/images/sriov-network-operator.yml
+++ b/images/sriov-network-operator.yml
@@ -1,3 +1,7 @@
+arches:
+- x86_64
+- aarch64
+- ppc64le
 content:
   source:
     dockerfile: Dockerfile.rhel7

--- a/images/sriov-network-webhook.yml
+++ b/images/sriov-network-webhook.yml
@@ -1,3 +1,7 @@
+arches:
+- x86_64
+- aarch64
+- ppc64le
 content:
   source:
     dockerfile: Dockerfile.webhook.rhel7


### PR DESCRIPTION
These operators are hardware specific, and nothing relevant is foreseen for IBM Z.
