### PR TITLE
Remove microdnf replacement for handler

### DIFF
--- a/images/openshift-kubernetes-nmstate-handler.yml
+++ b/images/openshift-kubernetes-nmstate-handler.yml
@@ -6,10 +6,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/kubernetes-nmstate.git
       web: https://github.com/openshift/kubernetes-nmstate
-    modifications:
-    - action: replace
-      match: microdnf
-      replacement: yum
 dependents:
 - openshift-kubernetes-nmstate-operator
 distgit:


### PR DESCRIPTION
Since we replaced microdnf with dnf in the handler image in
https://github.com/openshift/kubernetes-nmstate/pull/279/commits/6916942f6178af046b1c7b2c716ec332dfcdf278, this
modification is not needed anymore.

**Additional information:**
This "invalid" replacement lead to an error in the last build:

```
FAILURE: Error reconciling Dockerfile for openshift/ose-kubernetes-nmstate-handler-rhel8 in OCP v4.9


Why am I receiving this?
------------------------
You are receiving this message because you are listed as an owner for an
OpenShift related image - or you recently made a modification to the definition
of such an image in github. Upstream (github) OpenShift Dockerfiles are
regularly pulled from their upstream source and used as an input to build our
productized images - RHEL-based OpenShift Container Platform (OCP) images.

To serve as an input to RHEL/OCP images, upstream Dockerfiles are
programmatically modified before they are checked into a downstream git
repository which houses all Red Hat images:
 - https://pkgs.devel.redhat.com/cgit/containers/

We call this programmatic modification "reconciliation" and you will receive an
email when the upstream Dockerfile changes so that you can review the
differences between the upstream & downstream Dockerfiles.

What do I need to do?
---------------------
An error occurred during your reconciliation. Until this issue is addressed,
your upstream changes may not be reflected in the product build.

Please review the error message reported below to see if the issue is due to upstream
content. If it is not, the Automated Release Tooling (ART) team will engage to address
the issue. Please direct any questions to the ART team (#aos-art on slack).

Error Reported
--------------
openshift-kubernetes-nmstate-handler: Replace (microdnf->yum) modification did not make a change to the Dockerfile content
```