### PR TITLE
[release-4.8] Bug 2095360: Remove microdnf replacement for handler

### DIFF
--- a/images/openshift-kubernetes-nmstate-handler.yml
+++ b/images/openshift-kubernetes-nmstate-handler.yml
@@ -6,10 +6,6 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/kubernetes-nmstate.git
       web: https://github.com/openshift/kubernetes-nmstate
-    modifications:
-    - action: replace
-      match: microdnf
-      replacement: yum
 dependents:
 - openshift-kubernetes-nmstate-operator
 distgit:


### PR DESCRIPTION
Since we are replacing microdnf with dnf in the Dockerfile in https://github.com/openshift/kubernetes-nmstate/pull/280, this replacement
is not needed anymore.

/hold until https://github.com/openshift/kubernetes-nmstate/pull/280 got merged