### PR TITLE
Enable multi-arch release payloads in 4.11

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -12,6 +12,9 @@ arches:
 - s390x
 - aarch64
 
+multi_arch:
+  enabled: true
+
 operator_image_ref_mode: manifest-list
 
 # wip see: issues.redhat.com/browse/ART-3107


### PR DESCRIPTION
These can be skipped with a parameter in Jenkins or disabling them in assemblies.