### PR TITLE
rpms/openshift-clients.yml: reinstate rhel7 build

### DIFF
--- a/rpms/openshift-clients.yml
+++ b/rpms/openshift-clients.yml
@@ -8,3 +8,11 @@ content:
 name: openshift-clients
 owners:
 - aos-master@redhat.com
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-7
+targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-7-candidate  # internal build for ART purposes
+- rhaos-{MAJOR}.{MINOR}-rhel-8-candidate
+hotfix_targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-7-hotfix  # internal build for ART purposes
+- rhaos-{MAJOR}.{MINOR}-rhel-8-hotfix


### PR DESCRIPTION
[context](https://coreos.slack.com/archives/GDBRP5YJH/p1655312762440079?thread_ts=1655312478.874699&cid=GDBRP5YJH)

This would probably break if we don't keep golang updated equivalently in rhel-8 and rhel-7 buildroots.

Won't be shipped because we already dropped rhel-7 tags from our elliott sweeps.