### PR TITLE
4.12: Disable operators with versioned bundle directory

### DIFF
--- a/images/atomic-openshift-descheduler.yml
+++ b/images/atomic-openshift-descheduler.yml
@@ -10,8 +10,8 @@ content:
       streams_prs:
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
-dependents:
-- ose-cluster-kube-descheduler-operator
+# dependents:
+# - ose-cluster-kube-descheduler-operator # Disabled to wait for updated bundle dirs
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms

--- a/images/cluster-nfd-operator.yml
+++ b/images/cluster-nfd-operator.yml
@@ -1,3 +1,6 @@
+# Disabling until upstream updates channels for 4.12
+# ...or updates bundle dir to stable/
+mode: disabled
 content:
   source:
     dockerfile: Dockerfile

--- a/images/clusterresourceoverride-operator.yml
+++ b/images/clusterresourceoverride-operator.yml
@@ -1,3 +1,6 @@
+# Disabling until upstream updates channels for 4.12
+# ...or updates bundle dir to stable/
+mode: disabled
 content:
   source:
     dockerfile: Dockerfile.rhel7

--- a/images/kube-rbac-proxy.yml
+++ b/images/kube-rbac-proxy.yml
@@ -12,8 +12,8 @@ content:
           stream: rhel-8-golang-ci-build-root
 dependents:
 - ptp-operator
-- cluster-nfd-operator
-- special-resource-operator
+# - cluster-nfd-operator # Disabled to wait for updated bundle dirs
+# - special-resource-operator # Disabled to wait for updated bundle dirs
 - dpu-network-operator
 - ose-metallb-operator
 - local-storage-operator

--- a/images/node-feature-discovery.yml
+++ b/images/node-feature-discovery.yml
@@ -10,8 +10,8 @@ content:
       streams_prs:
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
-dependents:
-- cluster-nfd-operator
+# dependents:
+# - cluster-nfd-operator # Disabled to wait for updated bundle dirs
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms

--- a/images/openshift-kubernetes-nmstate-handler.yml
+++ b/images/openshift-kubernetes-nmstate-handler.yml
@@ -10,8 +10,8 @@ content:
       streams_prs:
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
-dependents:
-- openshift-kubernetes-nmstate-operator
+# dependents:
+# - openshift-kubernetes-nmstate-operator # Disabled to wait for updated bundle dirs
 distgit:
   component: openshift-kubernetes-nmstate-handler-rhel-8-container
 enabled_repos:

--- a/images/openshift-kubernetes-nmstate-operator.yml
+++ b/images/openshift-kubernetes-nmstate-operator.yml
@@ -1,3 +1,6 @@
+# Disabling until upstream updates channels for 4.12
+# ...or updates bundle dir to stable/
+mode: disabled
 content:
   source:
     dockerfile: build/Dockerfile.operator.openshift

--- a/images/ose-cluster-kube-descheduler-operator.yml
+++ b/images/ose-cluster-kube-descheduler-operator.yml
@@ -1,3 +1,6 @@
+# Disabling until upstream updates channels for 4.12
+# ...or updates bundle dir to stable/
+mode: disabled
 content:
   source:
     dockerfile: Dockerfile.rhel7

--- a/images/special-resource-operator.yml
+++ b/images/special-resource-operator.yml
@@ -1,3 +1,6 @@
+# Disabling until upstream updates channels for 4.12
+# ...or updates bundle dir to stable/
+mode: disabled
 content:
   source:
     dockerfile: Dockerfile

--- a/images/vertical-pod-autoscaler-operator.yml
+++ b/images/vertical-pod-autoscaler-operator.yml
@@ -1,3 +1,6 @@
+# Disabling until upstream updates channels for 4.12
+# ...or updates bundle dir to stable/
+mode: disabled
 content:
   source:
     dockerfile: Dockerfile.rhel7


### PR DESCRIPTION
Optional operators that refer to a specific version, say 4.11, need to
be disabled. Also images that declare themselves to be a member of a
disabled operator need to have that reference removed.

The commit was created with the following script (there is
at least one zsh-ism in here)

```sh
operators=( $(
  for f in images/*; do
    yq -r --arg f $f 'select(has("update-csv")) | select(."update-csv"."bundle-dir" | startswith("stable") | not) | $f' $f
  done
) )

for operator in ${operators[@]}; do
  echo '# Disabling until upstream updates channels for 4.12' >tmpfile
  echo '# ...or updates bundle dir to stable/' >>tmpfile
  echo 'mode: disabled' >>tmpfile
  cat $operator >>tmpfile
  mv tmpfile $operator
done

operands=( $(
  for image in images/*; do
    yq -er 'select(has("dependents")) | ""' $image && echo $image || :
  done
) )

disabled_operators=( $(
  git diff --name-only | sed -e 's,^images/,,' -e 's,\.yml$,,'
) )

git add images/

sed -i "s/^- \($(print -rl ${(j:\|:)disabled_operators[@]})\)$/# \\0 # Disabled to wait for updated bundle dirs/" ${operands[@]}

edited_operands=( $(git diff --name-only ) )

sed -i 's/^dependents:/# dependents:/' $(
  for i in ${edited_operands[@]}; do
    yq -r --arg i $i '.dependents | if type=="array" then "" else $i end' $i
done)

git add images/
git commit -evm '4.12: Disable operators with versioned bundle directory'
```