### PR TITLE
ART-4161 - Bump 4.11 golang to 1.18.2

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -21,8 +21,8 @@
 
 golang:
   # can be pulled from registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder@...
-  # openshift-golang-builder-container-v1.18.0-202204191948.sha1patch.el8.g4d4caca - 1.18.0 with sha1 patch
-  image: openshift/golang-builder@sha256:8e1cfc7198db25b97ce6f42e147b5c07d9725015ea971d04c91fe1249b565c80
+  # openshift-golang-builder-container-v1.18.2-202206222023.el8.gb30794b - 1.18.2
+  image: openshift/golang-builder@sha256:7698532bd826dd705305a46bbc29781655233b66a9977508f7e5e20a43f33ede
   mirror: true
   transform: rhel-8/golang
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-{MAJOR}.{MINOR}.art


### PR DESCRIPTION
Referenced Build: https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=46133877