### PR TITLE
4.12: Disable ironic images and repo temporarily

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -147,28 +147,6 @@ repos:
     reposync:
       latest_only: false
 
-  rhel-8-server-ironic-rpms:
-    conf:
-      extra_options:
-        module_hotfixes: 1  # play nicely with modules
-      baseurl:
-        aarch64: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el8-ironic/{runtime_assembly}/building/aarch64/os
-        ppc64le: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el8-ironic/{runtime_assembly}/building/ppc64le/os
-        s390x: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el8-ironic/{runtime_assembly}/building/s390x/os
-        x86_64: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el8-ironic/{runtime_assembly}/building/x86_64/os
-      ci_alignment:
-        profiles:
-        - el8
-        localdev:
-          enabled: true
-    content_set:  # TODO: replace with correct ironic content sets
-      default: rhocp-{MAJOR}.{MINOR}-for-rhel-8-x86_64-rpms
-      aarch64: rhocp-{MAJOR}.{MINOR}-for-rhel-8-aarch64-rpms
-      ppc64le: rhocp-{MAJOR}.{MINOR}-for-rhel-8-ppc64le-rpms
-      s390x: rhocp-{MAJOR}.{MINOR}-for-rhel-8-s390x-rpms
-    reposync:
-      latest_only: false
-
   # The installer team working with rhel-7 worker nodes needs rhel-7 rpms reposync'd.
   rhel-server-ose-rpms:
     conf:

--- a/images/ironic-agent.yml
+++ b/images/ironic-agent.yml
@@ -1,3 +1,4 @@
+mode: disabled
 arches:
 - x86_64
 - aarch64

--- a/images/ironic-rhcos-downloader.yml
+++ b/images/ironic-rhcos-downloader.yml
@@ -1,3 +1,4 @@
+mode: disabled
 arches:
 - x86_64
 - aarch64

--- a/images/ironic-static-ip-manager.yml
+++ b/images/ironic-static-ip-manager.yml
@@ -1,3 +1,4 @@
+mode: disabled
 arches:
 - x86_64
 - aarch64

--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -1,3 +1,4 @@
+mode: disabled
 arches:
 - x86_64
 - aarch64


### PR DESCRIPTION
Ironic tags have been set up to use rhel-9. The base image is not yet
ready. This commit temporarily disables ironic* images, as well as the
ironic repository to get 4.12 moving.

Related: https://github.com/openshift/ocp-build-data/pull/1686 