### PR TITLE
ose-agent-installer-node-agent: container tools from ose repo

### DIFF
--- a/images/ose-agent-installer-node-agent.yml
+++ b/images/ose-agent-installer-node-agent.yml
@@ -13,6 +13,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:


### PR DESCRIPTION
...and avoid these build-sync warnings:
```
assembly_issues:
  ose-agent-installer-node-agent:
  - code: OUTDATED_RPMS_IN_STREAM_BUILD
    msg: Found outdated RPM (conmon-2.1.0-1.module+el8.6.0+14877+f643d2d6) installed
      in ose-agent-installer-node-agent-container-v4.11.0-202206230818.p0.gd9f0877.assembly.stream
      when conmon-2.1.2-2.rhaos4.11.el8 was available
    permitted: true
  - code: OUTDATED_RPMS_IN_STREAM_BUILD
    msg: Found outdated RPM (fuse-overlayfs-1.8.2-1.module+el8.6.0+14877+f643d2d6)
      installed in ose-agent-installer-node-agent-container-v4.11.0-202206230818.p0.gd9f0877.assembly.stream
      when fuse-overlayfs-1.9-1.rhaos4.11.el8 was available
    permitted: true
  - code: OUTDATED_RPMS_IN_STREAM_BUILD
    msg: Found outdated RPM (podman-4.0.2-6.module+el8.6.0+14877+f643d2d6) installed
      in ose-agent-installer-node-agent-container-v4.11.0-202206230818.p0.gd9f0877.assembly.stream
      when podman-4.0.2-6.rhaos4.11.el8 was available
    permitted: true
  - code: OUTDATED_RPMS_IN_STREAM_BUILD
    msg: Found outdated RPM (podman-catatonit-4.0.2-6.module+el8.6.0+14877+f643d2d6)
      installed in ose-agent-installer-node-agent-container-v4.11.0-202206230818.p0.gd9f0877.assembly.stream
      when podman-catatonit-4.0.2-6.rhaos4.11.el8 was available
    permitted: true
  - code: OUTDATED_RPMS_IN_STREAM_BUILD
    msg: Found outdated RPM (runc-1.0.3-2.module+el8.6.0+14877+f643d2d6) installed
      in ose-agent-installer-node-agent-container-v4.11.0-202206230818.p0.gd9f0877.assembly.stream
      when runc-1.1.2-1.rhaos4.11.el8 was available
    permitted: true
  - code: OUTDATED_RPMS_IN_STREAM_BUILD
    msg: Found outdated RPM (containernetworking-plugins-1.0.1-2.module+el8.6.0+14877+f643d2d6)
      installed in ose-agent-installer-node-agent-container-v4.11.0-202206230818.p0.gd9f0877.assembly.stream
      when containernetworking-plugins-1.0.1-5.rhaos4.11.el8 was available
    permitted: true
  - code: OUTDATED_RPMS_IN_STREAM_BUILD
    msg: Found outdated RPM (libslirp-4.4.0-1.module+el8.6.0+14877+f643d2d6) installed
      in ose-agent-installer-node-agent-container-v4.11.0-202206230818.p0.gd9f0877.assembly.stream
      when libslirp-4.4.0-2.rhaos4.11.el8 was available
    permitted: true
  - code: OUTDATED_RPMS_IN_STREAM_BUILD
    msg: Found outdated RPM (criu-3.15-3.module+el8.6.0+14877+f643d2d6) installed
      in ose-agent-installer-node-agent-container-v4.11.0-202206230818.p0.gd9f0877.assembly.stream
      when criu-3.15-4.rhaos4.11.el8 was available
    permitted: true
```