### PR TITLE
[4.11] Reinstate openshift-ansible RPM, build for RHEL8

### DIFF
--- a/rpms/openshift-ansible.yml
+++ b/rpms/openshift-ansible.yml
@@ -1,0 +1,11 @@
+content:
+  source:
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/openshift-ansible.git
+    specfile: openshift-ansible.spec
+name: openshift-ansible
+owners:
+- rteague@redhat.com
+- sdodson@redhat.com


### PR DESCRIPTION
4.11 builds of openshift-ansible were stopped due to a build error.  However, the package is still needed for BYO RHEL (now 8).

The fix for the build error has been filed as https://github.com/openshift/openshift-ansible/pull/12398

This reverts commit 8a976dccad2bfeb73c7b63c422e986cf4146dd08.
