### PR TITLE
Disable baremetal-operator temporarily

### DIFF
--- a/images/ose-cluster-baremetal-operator.yml
+++ b/images/ose-cluster-baremetal-operator.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   source:
     git:


### PR DESCRIPTION
As follow-up of https://github.com/openshift/ocp-build-data/pull/1715,
to work around this error:

```
error: unable to create a release: operator "cluster-baremetal-operator" contained an invalid image-references file: no input image tag named "ironic"
```
https://amd64.ocp.releases.ci.openshift.org/releasestream/4.12.0-0.nightly/release/4.12.0-0.nightly-2022-06-24-053902