### PR TITLE
Exclude containernetworking-plugins from appstream repo

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -251,6 +251,8 @@ repos:
         - el8
         localdev:
           enabled: true
+      extra_options:
+        excludepkgs: containernetworking-plugins
     content_set:
       default: rhel-8-for-x86_64-appstream-eus-rpms__8_DOT_6
       aarch64: rhel-8-for-aarch64-appstream-eus-rpms__8_DOT_6
@@ -338,6 +340,8 @@ repos:
         - el9
         localdev:
           enabled: true
+      extra_options:
+        excludepkgs: containernetworking-plugins
     content_set:
       default: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_0
       aarch64: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_0


### PR DESCRIPTION
ose-ovn-kubernetes is getting the containernetworking-plugins from
appstream, as that module build has an epoch.

This excludes that package to get installed from the appstream repo in
favor of the ose repo.

Resulting test build: https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=46173701