### PR TITLE
[openshift-4.10] Bug 2100850: Add RHEL8 openshift-ansible RPM

### DIFF
--- a/rpms/openshift-ansible.yml
+++ b/rpms/openshift-ansible.yml
@@ -10,10 +10,12 @@ owners:
 - rteague@redhat.com
 - sdodson@redhat.com
 distgit:
-  # this is needed for RHEL 7 worker node support
+  # this started building and shipping for RHEL 7 first
   branch: rhaos-{MAJOR}.{MINOR}-rhel-7
 targets:
-- rhaos-{MAJOR}.{MINOR}-rhel-7-candidate  # this is needed for RHEL 7 worker node support
+- rhaos-{MAJOR}.{MINOR}-rhel-7-candidate  # kept for compatibility since we already shipped for RHEL 7
+- rhaos-{MAJOR}.{MINOR}-rhel-8-candidate  # this is needed for RHEL 8 worker node support
 hotfix_targets:
-- rhaos-{MAJOR}.{MINOR}-rhel-7-hotfix  # this is needed for RHEL 7 worker node support
+- rhaos-{MAJOR}.{MINOR}-rhel-7-hotfix  # kept for compatibility since we already shipped for RHEL 7
+- rhaos-{MAJOR}.{MINOR}-rhel-8-hotfix  # this is needed for RHEL 8 worker node support
 


### PR DESCRIPTION
This is essentially a backport of #1718.

OCP 4.9 added RHEL 8 worker nodes, and 4.10 dropped RHEL 7 worker node support.  Since it makes little sense to require a RHEL 7 system in order to configure a RHEL 8 host, openshift-ansible should have been moved to RHEL 8 by 4.10.  We're fixing that by adding a RHEL 8 RPM, but since the RHEL 7 RPM has already shipped in 4.10, it's probably too late to remove it.

This requires a backport of the build fix in https://github.com/openshift/openshift-ansible/pull/12400 as well as adding the package to the tag and creating the dist-git branch ([ticket](https://issues.redhat.com/browse/CLOUDBLD-10416)).

/cc @patrickdillon
