### PR TITLE
Exclude containernetworking-plugins from appstream repo

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -235,6 +235,8 @@ repos:
         - el8
         localdev:
           enabled: true
+      extra_options:
+        excludepkgs: containernetworking-plugins
     content_set:
       default: rhel-8-for-x86_64-appstream-eus-rpms__8_DOT_6
       aarch64: rhel-8-for-aarch64-appstream-eus-rpms__8_DOT_6


### PR DESCRIPTION
ose-ovn-kubernetes is getting the containernetworking-plugins from
appstream, as that module build has an epoch.

This excludes that package to get installed from the appstream repo in
favor of the ose repo.

Resulting test build: https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=46173701

Manual cherrypick of https://github.com/openshift/ocp-build-data/pull/1733