### PR TITLE
Fix buildconfig to match upstream

### DIFF
--- a/images/ironic-rhcos-downloader.yml
+++ b/images/ironic-rhcos-downloader.yml
@@ -15,6 +15,8 @@ enabled_repos:
 - openstack-16-for-rhel-8-rpms
 for_payload: true
 from:
+  builder:
+  - stream: golang
   member: openshift-base-rhel8
 name: openshift/ose-ironic-machine-os-downloader
 owners:


### PR DESCRIPTION
https://github.com/openshift/ironic-rhcos-downloader/pull/77 introduced
a new build stage. Update config to match