### PR TITLE
reinstate ironic with rhel9 base/repos

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -335,6 +335,48 @@ repos:
     reposync:
       enabled: false
 
+  rhel-9-server-ose-rpms-embargoed:
+    conf:
+      extra_options:
+        # Required to enable RPMs with higher NVRs to show up as installable options in the presence of modules from another repo.
+        # i.e. modules mask traditional rpms unless this flag is provided.
+        module_hotfixes: 1
+      baseurl:
+        aarch64: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el9/{runtime_assembly}/building-embargoed/aarch64/os
+        ppc64le: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el9/{runtime_assembly}/building-embargoed/ppc64le/os
+        s390x: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el9/{runtime_assembly}/building-embargoed/s390x/os
+        x86_64: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el9/{runtime_assembly}/building-embargoed/x86_64/os
+      # Do not add ci_alignment here. These RPMs should not be installed except for internal builds.
+    content_set:
+      default: rhocp-{MAJOR}.{MINOR}-for-rhel-9-x86_64-rpms
+      optional: true
+      aarch64: rhocp-{MAJOR}.{MINOR}-for-rhel-9-aarch64-rpms
+      ppc64le: rhocp-{MAJOR}.{MINOR}-for-rhel-9-ppc64le-rpms
+      s390x: rhocp-{MAJOR}.{MINOR}-for-rhel-9-s390x-rpms
+    reposync:
+      enabled: false
+
+  rhel-9-server-ose-rpms:
+    conf:
+      extra_options:
+        # Required to enable RPMs with higher NVRs to show up as installable options in the presence of modules from another repo.
+        # i.e. modules mask traditional rpms unless this flag is provided.
+        module_hotfixes: 1
+      baseurl:
+        aarch64: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el9/building/aarch64/os
+        ppc64le: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el9/building/ppc64le/os
+        s390x: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el9/building/s390x/os
+        x86_64: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}-el9/building/x86_64/os
+      ci_alignment:
+        profiles:
+        - el9
+        localdev:
+          enabled: true
+    content_set:  # keep empty to avoid being used in ART build or confusing elliott redundant content_set check
+      optional: true
+    reposync:
+      latest_only: false
+
   rhel-9-server-ironic-rpms:
     conf:
       extra_options:

--- a/group.yml
+++ b/group.yml
@@ -426,7 +426,7 @@ image_build_log_scanner:
   - orchestrator.log
 scan_freshness:
   release_regex: '(?x) ^ (\d\d\d\d) (\d\d) (\d\d) (\d\d)'
-  threshold_hours: 1
+  threshold_hours: 6
 csv_namespace: openshift
 # whether and how to check if all buildroots have consistent versions of golang compilers (rpm build only)
 # "x.y" (default): only major and minor version; "exact": the z-version must be the same; "no": do not check

--- a/images/ironic-agent.yml
+++ b/images/ironic-agent.yml
@@ -1,4 +1,3 @@
-mode: disabled
 arches:
 - x86_64
 - aarch64
@@ -12,7 +11,7 @@ content:
       web: https://github.com/openshift/ironic-agent-image
 for_payload: true
 from:
-  member: openshift-base-rhel8
+  member: openshift-base-rhel9
 name: openshift/ose-ironic-agent
 owners:
 - kni-devel@redhat.com
@@ -24,7 +23,7 @@ owners:
 - dhellmann@redhat.com
 - shardy@redhat.com
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms-embargoed
-- rhel-8-server-ironic-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+- rhel-9-server-ose-rpms-embargoed
+- rhel-9-server-ironic-rpms

--- a/images/ironic-rhcos-downloader.yml
+++ b/images/ironic-rhcos-downloader.yml
@@ -1,4 +1,3 @@
-mode: disabled
 arches:
 - x86_64
 - aarch64
@@ -11,15 +10,15 @@ content:
       url: git@github.com:openshift-priv/ironic-rhcos-downloader.git
       web: https://github.com/openshift/ironic-rhcos-downloader
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms-embargoed
-- rhel-8-server-ironic-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+- rhel-9-server-ose-rpms-embargoed
+- rhel-9-server-ironic-rpms
 for_payload: true
 from:
   builder:
   - stream: golang
-  member: openshift-base-rhel8
+  member: openshift-base-rhel9
 name: openshift/ose-ironic-machine-os-downloader
 owners:
 - ironic-osp-owners@redhat.com

--- a/images/ironic-static-ip-manager.yml
+++ b/images/ironic-static-ip-manager.yml
@@ -1,4 +1,3 @@
-mode: disabled
 arches:
 - x86_64
 - aarch64
@@ -11,13 +10,13 @@ content:
       url: git@github.com:openshift-priv/ironic-static-ip-manager.git
       web: https://github.com/openshift/ironic-static-ip-manager
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms-embargoed
-- rhel-8-server-ironic-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+- rhel-9-server-ose-rpms-embargoed
+- rhel-9-server-ironic-rpms
 for_payload: true
 from:
-  member: openshift-base-rhel8
+  member: openshift-base-rhel9
 name: openshift/ose-ironic-static-ip-manager
 owners:
 - ironic-osp-owners@redhat.com

--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -1,4 +1,3 @@
-mode: disabled
 arches:
 - x86_64
 - aarch64
@@ -11,15 +10,15 @@ content:
       url: git@github.com:openshift-priv/ironic-image.git
       web: https://github.com/openshift/ironic-image
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
-- rhel-8-server-ose-rpms-embargoed
-- rhel-8-server-ironic-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+- rhel-9-server-ose-rpms-embargoed
+- rhel-9-server-ironic-rpms
 for_payload: true
 from:
   builder:
-  - member: openshift-base-rhel8
-  member: openshift-base-rhel8
+  - member: openshift-base-rhel9
+  member: openshift-base-rhel9
 name: openshift/ose-ironic
 owners:
 - ironic-osp-owners@redhat.com

--- a/releases.yml
+++ b/releases.yml
@@ -14,3 +14,15 @@ releases:
         component: 'rhcos'
       - code: INCONSISTENT_RHCOS_RPMS
         component: 'rhcos'
+      members:
+        images:
+        - distgit_key: ironic
+          metadata:
+            is:
+              nvr: ironic-container-v4.11.0-202207070244.p0.gb1863f8.assembly.stream
+          why: "builds will fail until RHEL 9 content is ready"
+        - distgit_key: ironic-agent
+          metadata:
+            is:
+              nvr: ironic-agent-container-v4.11.0-202207070244.p0.gd84c963.assembly.stream
+          why: "builds will fail until RHEL 9 content is ready"


### PR DESCRIPTION
depends on https://github.com/openshift/aos-cd-jobs/pull/3131 as well as contents of el9 tags.