### PR TITLE
Do not ignore "Telco Edge" BZs

### DIFF
--- a/bug.yml
+++ b/bug.yml
@@ -39,7 +39,6 @@ filters:
     - "Node Maintenance Operator"
     - "Poison Pill Operator"
     - "Test Infrastructure"
-    - "Telco Edge"
   security:
     - "Quay"
     - "Test Framework"
@@ -57,4 +56,3 @@ filters:
     - "Performance Addon Operator"
     - "Node Maintenance Operator"
     - "Poison Pill Operator"
-    - "Telco Edge"

--- a/bugzilla.yml
+++ b/bugzilla.yml
@@ -72,9 +72,6 @@ filters:
     - field: "component"
       operator: "notequals"
       value: "Test Infrastructure"
-    - field: "component"
-      operator: "notequals"
-      value: "Telco Edge"
   security:
     - field: "component"
       operator: "notequals"
@@ -124,6 +121,3 @@ filters:
     - field: "component"
       operator: "notequals"
       value: "Poison Pill Operator"
-    - field: "component"
-      operator: "notequals"
-      value: "Telco Edge"


### PR DESCRIPTION
With the addition of new images on 4.10 (ART-4052, ART-4074, ART-4075, and ART-4076) we also need to sweep their corresponding bugs into advisories.