### PR TITLE
[4.11] use mainline RHEL repos

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -184,10 +184,11 @@ repos:
   rhel-8-baseos-rpms:
     conf:
       baseurl:
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/aarch64/baseos/os/
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/ppc64le/baseos/os/
-        s390x: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/s390x/baseos/os/
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/x86_64/baseos/os/
+        # NOTE: re-peg to 8.6 when 8.7 GA is pending
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/aarch64/baseos/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/ppc64le/baseos/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/baseos/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/
       ci_alignment:
         profiles:
         - el8
@@ -204,10 +205,11 @@ repos:
   rhel-8-codeready-builder-rpms:
     conf:
       baseurl:
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/aarch64/codeready-builder/os/
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/ppc64le/codeready-builder/os/
-        s390x: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/s390x/codeready-builder/os/
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/x86_64/codeready-builder/os/
+        # NOTE: re-peg to 8.6 when 8.7 GA is pending
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/aarch64/codeready-builder/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/ppc64le/codeready-builder/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/codeready-builder/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/codeready-builder/os/
       ci_alignment:
         profiles:
         - el8
@@ -224,11 +226,12 @@ repos:
   rhel-8-rt-rpms:
     conf:
       baseurl:
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.6/x86_64/rt/os/
+        # NOTE: re-peg to 8.6 when 8.7 GA is pending
+        x86_64:  http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/rt/os/
         # other arches don't exist, pointing at something that exists
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.6/x86_64/rt/os/
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.6/x86_64/rt/os/
-        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8.6/x86_64/rt/os/
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/rt/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/rt/os/
+        s390x:   http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/rt/os/
       ci_alignment:
         profiles:
         - el8
@@ -242,10 +245,11 @@ repos:
   rhel-8-appstream-rpms:
     conf:
       baseurl:
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/aarch64/appstream/os/
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/ppc64le/appstream/os/
-        s390x: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/s390x/appstream/os/
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/eus/rhel8/8.6/x86_64/appstream/os/
+        # NOTE: re-peg to 8.6 when 8.7 GA is pending
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/aarch64/appstream/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/ppc64le/appstream/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/s390x/appstream/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/
       ci_alignment:
         profiles:
         - el8

--- a/group.yml
+++ b/group.yml
@@ -315,10 +315,11 @@ repos:
   rhel-9-baseos-rpms:
     conf:
       baseurl:
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/aarch64/baseos/os/
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/ppc64le/baseos/os/
-        s390x: http://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/s390x/baseos/os/
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/x86_64/baseos/os/
+        # NOTE: re-peg to 9.0 when 9.1 GA is pending
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/s390x/baseos/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/
       ci_alignment:
         profiles:
         - el9
@@ -335,10 +336,11 @@ repos:
   rhel-9-appstream-rpms:
     conf:
       baseurl:
-        aarch64: http://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/aarch64/appstream/os/
-        ppc64le: http://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/ppc64le/appstream/os/
-        s390x: http://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/s390x/appstream/os/
-        x86_64: http://rhsm-pulp.corp.redhat.com/content/eus/rhel9/9.0/x86_64/appstream/os/
+        # NOTE: re-peg to 9.0 when 9.1 GA is pending
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/s390x/appstream/os/
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/
       ci_alignment:
         profiles:
         - el9


### PR DESCRIPTION
Per [slack](https://coreos.slack.com/archives/CB95J6R4N/p1657130672594489?thread_ts=1657006519.906429&cid=CB95J6R4N) and [Jira](https://issues.redhat.com/browse/RHELDST-6698?focusedCommentId=18475590&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-18475590) rhsm-pulp does not reliably keep minor z-stream repos updated until the next minor RHEL version releases and the z-stream becomes associated with the minor. So use the major release repos until then.

Did not see a reason to change the content sets.
