### PR TITLE
group.yml: use successful 4.12 RHCOS builds

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -62,9 +62,6 @@ urls:
   cgit: http://pkgs.devel.redhat.com/cgit
   # temporarily point at 4.11 until 4.12 RHCOS gets rolling
   rhcos_release_base:
-    x86_64: https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.11
-    s390x: https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.11-s390x
-    ppc64le: https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.11-ppc64le
     aarch64: https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.11-aarch64
 dist_git_ignore:
   - gating.yaml


### PR DESCRIPTION
3 of 4 are working now.