### PR TITLE
group.yml: use the arm64 RHCOS builds

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -60,9 +60,6 @@ urls:
   brew_image_host: registry-proxy.engineering.redhat.com
   brew_image_namespace: rh-osbs
   cgit: http://pkgs.devel.redhat.com/cgit
-  # temporarily point at 4.11 until 4.12 RHCOS gets rolling
-  rhcos_release_base:
-    aarch64: https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.11-aarch64
 dist_git_ignore:
   - gating.yaml
 


### PR DESCRIPTION
https://releases-rhcos-art.cloud.privileged.psi.redhat.com/?stream=releases/rhcos-4.12-aarch64 exists now