### PR TITLE
images/cluster-version-operator: auto_label for merge

### DIFF
--- a/images/cluster-version-operator.yml
+++ b/images/cluster-version-operator.yml
@@ -8,6 +8,13 @@ content:
       web: https://github.com/openshift/cluster-version-operator
     ci_alignment:
       streams_prs:
+        auto_label:
+        - approved
+        - backport-risk-assessed
+        - bugzilla/valid-bug
+        - cherry-pick-approved
+        - lgtm
+        - staff-eng-approved
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
 enabled_repos:


### PR DESCRIPTION
Currently 4.12 is the dev release, so it [only needs `lgtm` and `approved`][1].  But eventually 4.12 will hit code-freeze, and then it will also [need `bugzilla/valid-bug` and `staff-eng-approved`][2].  And eventually it will be a generally available release, and then it will [need `approved`, `backport-risk-assessed`, `bugzilla/valid-bug`, `cherry-pick-approved`, and `lgtm`][3].  The CVO is very flexible about Go versions and whatnot, so we don't need any of these sign-offs for CI-alignment pull requests.  With this commit, we add all the labels we'll need to merge at any stage of the 4.12 lifecycle.  And hopefully the same configuration will propagate into 4.13 once we get release branches here for that.

[1]: https://github.com/openshift/release/blob/7114512b31971dcfe83454a40ed77f8881cecc73/core-services/prow/02_config/openshift/cluster-version-operator/_prowconfig.yaml#L57-L62
[2]: https://github.com/openshift/release/blob/7114512b31971dcfe83454a40ed77f8881cecc73/core-services/prow/02_config/openshift/cluster-version-operator/_prowconfig.yaml#L40-L47
[3]: https://github.com/openshift/release/blob/7114512b31971dcfe83454a40ed77f8881cecc73/core-services/prow/02_config/openshift/cluster-version-operator/_prowconfig.yaml#L3-L30