### PR TITLE
[ART-4218] Stop shipping jenkins for 3.11

### DIFF
--- a/images/jenkins-agent-maven-35-rhel7.yml
+++ b/images/jenkins-agent-maven-35-rhel7.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   source:
     dockerfile: Dockerfile.rhel7

--- a/images/jenkins-agent-maven-36-rhel7.yml
+++ b/images/jenkins-agent-maven-36-rhel7.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   source:
     dockerfile: Dockerfile.rhel7

--- a/images/jenkins-agent-nodejs-12-rhel7.yml
+++ b/images/jenkins-agent-nodejs-12-rhel7.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   source:
     dockerfile: Dockerfile.rhel7

--- a/images/jenkins-slave-base-rhel7.yml
+++ b/images/jenkins-slave-base-rhel7.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   source:
     dockerfile: Dockerfile.rhel7

--- a/images/openshift-jenkins-2.yml
+++ b/images/openshift-jenkins-2.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   source:
     dockerfile: Dockerfile.rhel7


### PR DESCRIPTION
As per
https://drive.google.com/file/d/1z66r7wERKq7hrvlm1KW7muh4ViL0tdZZ/view,
jenkins artifacts are not part of the Extended Life Cycle Support Add-On
offering. This commit stops to build the images.