### PR TITLE
Align kubernetes-nmstate bundle dir with new bundle structure

### DIFF
--- a/images/openshift-kubernetes-nmstate-operator.yml
+++ b/images/openshift-kubernetes-nmstate-operator.yml
@@ -33,7 +33,7 @@ owners:
 - phoracek@redhat.com
 - yboaron@redhat.com
 update-csv:
-  bundle-dir: '{MAJOR}.{MINOR}/'
+  bundle-dir: '{MAJOR}.{MINOR}/manifests'
   manifests-dir: manifests/
   registry: image-registry.openshift-image-registry.svc:5000
   valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'


### PR DESCRIPTION
In openshift/kubernetes-nmstate/pull/285 we store the bundle manifests in the supposed bundle structure from the operator-sdk. This PR aligns the bundle dir for CSV with these changes.

/hold as it should merge the same tide as openshift/kubernetes-nmstate/pull/285 (which updates the bundle directory path and includes the 4.12 manifests)