### PR TITLE
Enable GCP images on ARM

### DIFF
--- a/images/ose-gcp-cloud-controller-manager.yml
+++ b/images/ose-gcp-cloud-controller-manager.yml
@@ -1,6 +1,7 @@
 arches:
 - x86_64
 - ppc64le
+- aarch64
 content:
   source:
     git:

--- a/images/ose-gcp-cluster-api-controllers.yml
+++ b/images/ose-gcp-cluster-api-controllers.yml
@@ -1,6 +1,7 @@
 arches:
 - x86_64
 - ppc64le
+- aarch64
 content:
   source:
     dockerfile: openshift/Dockerfile.openshift

--- a/images/ose-gcp-pd-csi-driver-operator.yml
+++ b/images/ose-gcp-pd-csi-driver-operator.yml
@@ -1,6 +1,7 @@
 arches:
 - x86_64
 - ppc64le
+- aarch64
 content:
   source:
     dockerfile: Dockerfile.openshift

--- a/images/ose-gcp-pd-csi-driver.yml
+++ b/images/ose-gcp-pd-csi-driver.yml
@@ -1,6 +1,7 @@
 arches:
 - x86_64
 - ppc64le
+- aarch64
 content:
   source:
     dockerfile: Dockerfile.openshift

--- a/images/ose-machine-api-provider-gcp.yml
+++ b/images/ose-machine-api-provider-gcp.yml
@@ -1,6 +1,7 @@
 arches:
 - x86_64
 - ppc64le
+- aarch64
 content:
   source:
     dockerfile: Dockerfile.rhel


### PR DESCRIPTION
This is just to enable early development for now, depending on how things go, this may be reverted before 4.12 RC.
