### PR TITLE
Temporarily disable microshift

### DIFF
--- a/rpms/microshift.yml
+++ b/rpms/microshift.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   source:
     git:


### PR DESCRIPTION
ART's automation doesn't support excluding a component from a release yet. Temporarily disable microshift for 4.10.24 release preparation. 