### PR TITLE
Revert "Temporarily disable microshift"

### DIFF
--- a/rpms/microshift.yml
+++ b/rpms/microshift.yml
@@ -1,4 +1,3 @@
-mode: disabled
 content:
   source:
     git:


### PR DESCRIPTION
Reverts openshift/ocp-build-data#1799

/hold until 4.10.24 is promoted.