### PR TITLE
rpms/openshift{,-clients}: enable el9 builds

### DIFF
--- a/rpms/openshift-clients.yml
+++ b/rpms/openshift-clients.yml
@@ -8,3 +8,9 @@ content:
 name: openshift-clients
 owners:
 - aos-master@redhat.com
+targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-8-candidate
+- rhaos-{MAJOR}.{MINOR}-rhel-9-candidate
+hotfix_targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-8-hotfix
+- rhaos-{MAJOR}.{MINOR}-rhel-9-hotfix

--- a/rpms/openshift.yml
+++ b/rpms/openshift.yml
@@ -13,4 +13,9 @@ content:
 name: openshift
 owners:
 - aos-master@redhat.com
-- ccoleman@redhat.com
+targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-8-candidate
+- rhaos-{MAJOR}.{MINOR}-rhel-9-candidate
+hotfix_targets:
+- rhaos-{MAJOR}.{MINOR}-rhel-8-hotfix
+- rhaos-{MAJOR}.{MINOR}-rhel-9-hotfix


### PR DESCRIPTION
This ran fine in test before but I was waiting until the buildroots got synchronized golang versions (was 1.18.0 vs 1.18.2). This should be good now.