### PR TITLE
[4.11] streams: update golang to 1.18.4

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -21,8 +21,8 @@
 
 golang:
   # can be pulled from registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder@...
-  # openshift-golang-builder-container-v1.18.2-202206222023.el8.gb30794b - 1.18.2
-  image: openshift/golang-builder@sha256:7698532bd826dd705305a46bbc29781655233b66a9977508f7e5e20a43f33ede
+  # openshift-golang-builder-container-v1.18.4-202207291631.el8.g2ee6935
+  image: openshift/golang-builder@sha256:66bd53b5f180fb080e164fd97c7aac173ac1a15e7582321f6c0934b39fb50225
   mirror: true
   transform: rhel-8/golang
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-{MAJOR}.{MINOR}.art
@@ -42,8 +42,8 @@ rhel-8-golang-ci-build-root:
 # approval to diverge from what kube apiserver uses for a given release.
 # https://coreos.slack.com/archives/CB95J6R4N/p1598453188186800?thread_ts=1598449075.172000&cid=CB95J6R4N
 etcd_golang:
-  # openshift-golang-builder-container-v1.16.12-202202072221.el8.g92a7afd
-  image: openshift/golang-builder@sha256:21aab8ec0f5d119e4f6dab12f7ad6a1cec15d5f9071ae0c7431be760f29d4c71
+  # openshift-golang-builder-container-v1.16.12-202208011952.el8.g58dffad
+  image: openshift/golang-builder@sha256:ca32011a8331e8369f2150e56c39e851dd3e2536a04772eb2577553e6ab380f0
   mirror: true
   # No transform required as etcd does not yum install any packages.
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-etcd-golang-1.16


### PR DESCRIPTION
Update: now also updates etcd golang for CVE fix.