### PR TITLE
[openshift-4.12] Bug 2114968: Revert "releases.yml: remove ironic pins now that they build"

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -17,3 +17,15 @@ releases:
       - code: MISSING_RHCOS_CONTAINER
         component: 'rhel-coreos-8'
         # why: for now this has not rolled out to non-x86
+      members:
+        images:
+        - distgit_key: ironic
+          metadata:
+            is:
+              nvr: ironic-container-v4.11.0-202207070244.p0.gb1863f8.assembly.stream
+          why: "builds will fail until RHEL 9 content is ready"
+        - distgit_key: ironic-agent
+          metadata:
+            is:
+              nvr: ironic-agent-container-v4.11.0-202207070244.p0.gd84c963.assembly.stream
+          why: "builds will fail until RHEL 9 content is ready"


### PR DESCRIPTION
This reverts commit 00ee8e9730f667f73d115eb63cb797077d7c634b to mitigate https://issues.redhat.com/browse/TRT-444

Per [TRT policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get ci and/or nightly payloads flowing again.

We believe this is causing 4.12 nightly payload failures as mentioned in [TRT-444](https://issues.redhat.com//browse/TRT-444).

cc: @elfosardo (who has a [fix in mind already](https://github.com/openshift/ironic-agent-image/pull/59))

