### PR TITLE
Remove advisories from group.yml

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -17,13 +17,6 @@ operator_image_ref_mode: manifest-list
 # wip see: issues.redhat.com/browse/ART-3107
 operator_channel_stable: default
 
-advisories:
-  image: 1
-  rpm: 1
-  extras: 1
-  metadata: 1
-  # security:
-
 signing_advisory: 81157
 
 build_profiles:


### PR DESCRIPTION
With assemblies, they are not needed and may cause confusion to our
automation.