### PR TITLE
Remove advisories from group.yml

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -15,13 +15,6 @@ arches:
 operator_image_ref_mode: manifest-list
 operator_channel_stable: default
 
-advisories:
-  image: 1
-  rpm: 1
-  extras: 1
-  metadata: 1
-  # security:
-
 signing_advisory: 81219
 
 build_profiles:


### PR DESCRIPTION
With assemblies, they are not needed and may cause confusion to our
automation.