### PR TITLE
Remove advisories from group.yml

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -14,12 +14,6 @@ arches:
 operator_image_ref_mode: manifest-list
 operator_channel_stable: extra
 
-advisories:
-  image: 81200
-  rpm: 81199
-  extras: 81201
-  metadata: 81202
-
 signing_advisory: 68847
 
 build_profiles:
@@ -300,4 +294,3 @@ csv_namespace: openshift
 # whether and how to check if all buildroots have consistent versions of golang compilers (rpm build only)
 # "x.y" (default): only major and minor version; "exact": the z-version must be the same; "no": do not check
 check_golang_versions: "exact"
-


### PR DESCRIPTION
With assemblies, they are not needed and may cause confusion to our
automation.