### PR TITLE
Remove advisories from group.yml

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -14,12 +14,6 @@ arches:
 operator_image_ref_mode: manifest-list
 operator_channel_stable: extra
 
-advisories:
-  image: 81149
-  rpm: 81148
-  extras: 81151
-  metadata: 81152
-
 signing_advisory: 68848
 
 assemblies:


### PR DESCRIPTION
With assemblies, they are not needed and may cause confusion to our
automation.