### PR TITLE
[ART-3911] stop building ose-power-machine-controllers for x86

### DIFF
--- a/images/ovn-kubernetes-base.yml
+++ b/images/ovn-kubernetes-base.yml
@@ -10,6 +10,8 @@ content:
       streams_prs:
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
+dependents:
+- ovn-kubernetes-singlenode
 distgit:
   component: ose-ovn-kubernetes-base-container
 enabled_repos:

--- a/images/ovn-kubernetes-base.yml
+++ b/images/ovn-kubernetes-base.yml
@@ -1,0 +1,25 @@
+content:
+  source:
+    dockerfile: Dockerfile.base
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift/ovn-kubernetes.git
+      web: https://github.com/openshift/ovn-kubernetes.git
+    ci_alignment:
+      streams_prs:
+        ci_build_root:
+          stream: rhel-8-golang-ci-build-root
+distgit:
+  component: ose-ovn-kubernetes-base-container
+enabled_repos:
+- rhel-8-baseos-rpms
+- rhel-8-appstream-rpms
+- rhel-8-fast-datapath-rpms
+- rhel-8-server-ose-rpms-embargoed
+for_payload: false
+from:
+  member: openshift-enterprise-base
+name: openshift/ovn-kubernetes-base
+owners:
+- aos-networking-staff@redhat.com

--- a/images/ovn-kubernetes-singlenode.yml
+++ b/images/ovn-kubernetes-singlenode.yml
@@ -1,0 +1,27 @@
+content:
+  source:
+    dockerfile: Dockerfile.microshift
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift/ovn-kubernetes.git
+      web: https://github.com/openshift/ovn-kubernetes.git
+    ci_alignment:
+      streams_prs:
+        ci_build_root:
+          stream: rhel-8-golang-ci-build-root
+distgit:
+  component: ovn-kubernetes-singlenode-container
+enabled_repos:
+- rhel-8-baseos-rpms
+- rhel-8-appstream-rpms
+- rhel-8-fast-datapath-rpms
+- rhel-8-server-ose-rpms-embargoed
+for_payload: false
+from:
+  builder:
+  - stream: golang
+  member: openshift-enterprise-base
+name: openshift/ovn-kubernetes-singlenod
+owners:
+- aos-networking-staff@redhat.com


### PR DESCRIPTION
ose-power-machine-controllers is a ppc64 only image. It's not clear if https://issues.redhat.com/browse/ART-3417 has been fixed along the way, 4.12 seems to be the right playground to check this.