### PR TITLE
[4.6] consolidate bug.yml with bugzilla.yml

### DIFF
--- a/bug.yml
+++ b/bug.yml
@@ -21,10 +21,6 @@ version:
 # to be ignored when looking for bugs to be attached to OCP advisories
 filters:
   default:
-    - "Quay"
-    - "Test Framework"
-    - "assisted-installer"
-    - "cluster loader"
     - "RFE"
     - "Documentation"
     - "Security"
@@ -34,17 +30,12 @@ filters:
     - "File Integrity Operator"
     - "Compliance Operator"
     - "OpenShift Update Service"
-    - "Logging"
     - "Performance Addon Operator"
     - "Node Maintenance Operator"
     - "Poison Pill Operator"
     - "Test Infrastructure"
     - "Telco Edge"
   security:
-    - "Quay"
-    - "Test Framework"
-    - "assisted-installer"
-    - "cluster loader"
     - "RFE"
     - "Documentation"
     - "Migration Tooling"
@@ -53,7 +44,6 @@ filters:
     - "File Integrity Operator"
     - "Compliance Operator"
     - "OpenShift Update Service"
-    - "Logging"
     - "Performance Addon Operator"
     - "Node Maintenance Operator"
     - "Poison Pill Operator"


### PR DESCRIPTION
There was an error in populating bug.yml with components
that don't belong to 4.6. Restore this list back to what's in
bugzilla.yml