### PR TITLE
releases: update 4.10.31 to newer nightlies for kernel update

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -2,12 +2,12 @@ releases:
   4.10.31:
     assembly:
       basis:
-        brew_event: 46997223
+        brew_event: 47015862
         reference_releases:
-          aarch64: 4.10.0-0.nightly-arm64-2022-08-30-180623
-          ppc64le: 4.10.0-0.nightly-ppc64le-2022-08-30-180232
-          s390x: 4.10.0-0.nightly-s390x-2022-08-30-180320
-          x86_64: 4.10.0-0.nightly-2022-08-30-180151
+          aarch64: 4.10.0-0.nightly-arm64-2022-08-31-063823
+          ppc64le: 4.10.0-0.nightly-ppc64le-2022-08-31-063700
+          s390x: 4.10.0-0.nightly-s390x-2022-08-31-063741
+          x86_64: 4.10.0-0.nightly-2022-08-31-063608
       group:
         advisories:
           extras: 101102
@@ -22,10 +22,10 @@ releases:
       rhcos:
         machine-os-content:
           images:
-            aarch64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:0bda750b63f90404cfc738f73995027ea12c66520c3842eec2ad9a1efc8a2e89
-            ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:e34b2db5f426ca0ad1779c3fb30e236155c10330e8009e0e46d2012112811566
-            s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:00137e72116a131cdb32c76895ddcdc35f7c48d1fabce3887a49fa47205cc72f
-            x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:ccc430045b26a463c6f8869d64807ed62585c2ce3a9d9aefe981a7b0ea851a3a
+            aarch64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:63e549a446da89543d00f0a250afdf458df66497dd48db02fdb3175e2497add5
+            ppc64le: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:79b0793ba337588533fa3614b3901f03cb67522f1a0d77d701874995dc740ec0
+            s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:42ec8b051e718f91c0ffa61d9f407c6929ee9d40e4d2e8e1c9d599d518c1c6ac
+            x86_64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:65b3a1498fc315fd65b65fb6bc38ba4c9fe90b09e0aa27eeda4f8c9c9522bebe
       type: standard
   "4.10.30":
     assembly:


### PR DESCRIPTION
Earlier nightlies were chosen previously in order to avoid a regression (a fix in RHEL 8.4.z before 8.6.z). This is waived and the newer nightlies should include that fix.