### PR TITLE
update valid-subscription

### DIFF
--- a/images/ose-aws-efs-csi-driver-operator.yml
+++ b/images/ose-aws-efs-csi-driver-operator.yml
@@ -30,4 +30,4 @@ update-csv:
   bundle-dir: '{MAJOR}.{MINOR}/'
   manifests-dir: config/manifests
   registry: image-registry.openshift-image-registry.svc:5000
-  valid-subscription-label: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
+  valid-subscription-label: '["OpenShift Container Platform", "OpenShift Platform Plus"]'


### PR DESCRIPTION
according to cvp test failure http://external-ci-coldstorage.datahub.redhat.com/cvp/cvp-redhat-operator-bundle-image-validation-test/ose-aws-efs-csi-driver-operator-bundle-container-v4.10.0.202208250735.p0.gdb7e452.assembly.stream-1/6f9253de-236e-48df-9b93-621fc013yutr/operator-valid-subscriptions-bundle-image-output.txt