### PR TITLE
images/ose-cluster-kube-descheduler-operator: re-enable

### DIFF
--- a/images/atomic-openshift-descheduler.yml
+++ b/images/atomic-openshift-descheduler.yml
@@ -10,8 +10,8 @@ content:
       streams_prs:
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
-# dependents:
-# - ose-cluster-kube-descheduler-operator # Disabled to wait for updated bundle dirs
+dependents:
+- ose-cluster-kube-descheduler-operator # Disabled to wait for updated bundle dirs
 enabled_repos:
 - rhel-8-appstream-rpms
 - rhel-8-baseos-rpms

--- a/images/ose-cluster-kube-descheduler-operator.yml
+++ b/images/ose-cluster-kube-descheduler-operator.yml
@@ -1,6 +1,3 @@
-# Disabling until upstream updates channels for 4.12
-# ...or updates bundle dir to stable/
-mode: disabled
 content:
   source:
     dockerfile: Dockerfile.rhel7


### PR DESCRIPTION
Should be fixed up per
https://github.com/openshift/cluster-kube-descheduler-operator/commit/99a002b48361c8b8992d8eb2347358fa530c58dd