### PR TITLE
Add missing build stage

### DIFF
--- a/images/ose-agent-installer-api-server.yml
+++ b/images/ose-agent-installer-api-server.yml
@@ -17,6 +17,7 @@ for_payload: true
 from:
   builder:
   - stream: golang
+  - stream: rhel9
   - member: openshift-enterprise-cli
   member: openshift-enterprise-base
 name: openshift/ose-agent-installer-api-server


### PR DESCRIPTION
An additional build stage has been introduced upstream: https://github.com/openshift/assisted-service/commit/151f68b08d2f0e9111bc5115ba88482e675997a0#diff-b30fb02587208d9c8a793ae835c6fdd8bdc88657b7fe0f7b244e63b42430aad3R2. This configuration change tries to match centos:stream9 with our rhel9 stream