### PR TITLE
Update ec.3 definition

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -10,7 +10,13 @@ releases:
           x86_64: 4.12.0-0.nightly-2022-09-14-101116
       group: {}
       members:
-        images: []
+        images:
+        - distgit_key: ingress-node-firewall
+          why: component name changed after brew event
+          metadata:
+            distgit:
+              component: ose-ingress-node-firewall-container
+              bundle_component: ose-ingress-node-firewall-operator-bundle-container
         rpms: []
       rhcos:
         machine-os-content:


### PR DESCRIPTION
Component name for ingress-node-firewall changed after brew event. Need to use the old name in ec.3.