### PR TITLE
Fix rebase of ironic-rhcos-downloader

### DIFF
--- a/images/ironic-rhcos-downloader.yml
+++ b/images/ironic-rhcos-downloader.yml
@@ -15,6 +15,8 @@ enabled_repos:
 - openstack-16-for-rhel-8-rpms
 for_payload: true
 from:
+  builder:
+  - stream: golang
   member: openshift-base-rhel8
 name: openshift/ose-ironic-machine-os-downloader
 owners:


### PR DESCRIPTION
Following https://github.com/openshift/ironic-rhcos-downloader/commit/cc369e6f1051f042b941e69ee7f9d486249189f2, a new build stage needs to be declared.