### PR TITLE
4.12: Add ose repo to nmstate consuming images

### DIFF
--- a/images/openshift-kubernetes-nmstate-handler.yml
+++ b/images/openshift-kubernetes-nmstate-handler.yml
@@ -17,6 +17,7 @@ distgit:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: false
 from:
   builder:

--- a/images/ose-agent-installer-api-server.yml
+++ b/images/ose-agent-installer-api-server.yml
@@ -13,6 +13,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:

--- a/images/ose-image-customization-controller.yml
+++ b/images/ose-image-customization-controller.yml
@@ -15,6 +15,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: true
 from:
   builder:


### PR DESCRIPTION
nmstate got tagged into 4.12 rhel-8 tag. This commit ensures that all nmstate consuming images consume the ose selected build.

As the ose repo is enabled by default in CI, this ensures that CI tests what ART builds.

Context: https://issues.redhat.com/browse/CLOUDBLD-11049