### PR TITLE
[ART-4558] move ironic images to rhel9 branch

### DIFF
--- a/images/ironic-agent.yml
+++ b/images/ironic-agent.yml
@@ -9,6 +9,8 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ironic-agent-image.git
       web: https://github.com/openshift/ironic-agent-image
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 for_payload: true
 from:
   member: openshift-base-rhel9

--- a/images/ironic-rhcos-downloader.yml
+++ b/images/ironic-rhcos-downloader.yml
@@ -9,6 +9,8 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ironic-rhcos-downloader.git
       web: https://github.com/openshift/ironic-rhcos-downloader
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ironic-static-ip-manager.yml
+++ b/images/ironic-static-ip-manager.yml
@@ -9,6 +9,8 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ironic-static-ip-manager.git
       web: https://github.com/openshift/ironic-static-ip-manager
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms

--- a/images/ironic.yml
+++ b/images/ironic.yml
@@ -9,6 +9,8 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/ironic-image.git
       web: https://github.com/openshift/ironic-image
+distgit:
+  branch: rhaos-{MAJOR}.{MINOR}-rhel-9
 enabled_repos:
 - rhel-9-baseos-rpms
 - rhel-9-appstream-rpms


### PR DESCRIPTION
This will help doozer logic compare against the right RPM candidate tag. Requires https://issues.redhat.com/browse/CLOUDBLD-11118

/hold
until complete