### PR TITLE
[4.12] Fix and update arches in cloud-specific images

### DIFF
--- a/images/ibm-vpc-node-label-updater.yml
+++ b/images/ibm-vpc-node-label-updater.yml
@@ -1,6 +1,5 @@
 arches:
 - x86_64
-- ppc64le
 content:
   source:
     dockerfile: Dockerfile.openshift

--- a/images/ose-gcp-filestore-csi-driver-operator.yml
+++ b/images/ose-gcp-filestore-csi-driver-operator.yml
@@ -1,3 +1,7 @@
+arches:
+- x86_64
+- ppc64le
+- aarch64
 content:
   source:
     dockerfile: Dockerfile.openshift

--- a/images/ose-gcp-filestore-csi-driver.yml
+++ b/images/ose-gcp-filestore-csi-driver.yml
@@ -1,3 +1,7 @@
+arches:
+- x86_64
+- ppc64le
+- aarch64
 content:
   source:
     dockerfile: Dockerfile.openshift

--- a/images/ose-ibm-cloud-controller-manager.yml
+++ b/images/ose-ibm-cloud-controller-manager.yml
@@ -1,6 +1,5 @@
 arches:
 - x86_64
-- ppc64le
 content:
   source:
     dockerfile: openshift-hack/images/Dockerfile.openshift

--- a/images/ose-ibm-vpc-block-csi-driver-operator.yml
+++ b/images/ose-ibm-vpc-block-csi-driver-operator.yml
@@ -1,6 +1,5 @@
 arches:
 - x86_64
-- ppc64le
 content:
   source:
     git:

--- a/images/ose-ibm-vpc-block-csi-driver.yml
+++ b/images/ose-ibm-vpc-block-csi-driver.yml
@@ -1,6 +1,5 @@
 arches:
 - x86_64
-- ppc64le
 content:
   source:
     dockerfile: Dockerfile.openshift

--- a/images/ose-ibmcloud-machine-controllers.yml
+++ b/images/ose-ibmcloud-machine-controllers.yml
@@ -1,6 +1,5 @@
 arches:
 - x86_64
-- ppc64le
 content:
   source:
     git:


### PR DESCRIPTION
- Set arches in new GCP images
- Drop ppc64le from IBM Cloud VPC images
