### PR TITLE
ptp-operator: fix CVP optional check failures

### DIFF
--- a/images/ptp-operator.yml
+++ b/images/ptp-operator.yml
@@ -25,6 +25,8 @@ from:
   - stream: golang
   member: openshift-enterprise-base
 name: openshift/ose-ptp-operator
+labels:
+  summary: Operator that manages PTP (Precision Time Protocol) configuration on an openshift cluster
 owners:
 - multus-dev@redhat.com
 update-csv:


### PR DESCRIPTION
  move summary field under labels
  http://external-ci-coldstorage.datahub.redhat.com/cvp/cvp-product-test/ose-ptp-operator-container-v4.12.0-202209231957.p0.g4e588c9.assembly.stream/91325cc3-3d1e-4bc0-87ed-43273fcfc226/sanity-tests-optional-results.json