### PR TITLE
releases: tweak permits

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -118,11 +118,8 @@ releases:
     assembly:
       type: stream
       permits:
-      - code: OUTDATED_RPMS_IN_STREAM_BUILD
-        component: 'ironic'
-        # why: https://issues.redhat.com/browse/ART-4558
-      - code: OUTDATED_RPMS_IN_STREAM_BUILD
-        component: 'ironic-rhcos-downloader'
-        # why: https://issues.redhat.com/browse/ART-4558
       - code: INCONSISTENT_RHCOS_RPMS
         component: 'rhcos'
+      - code: OUTDATED_RPMS_IN_STREAM_BUILD
+        component: 'rhcos'
+        # why: ARM builds are failing and we want more nightlies


### PR DESCRIPTION
ironic builds no longer need permits.
but we do need to ignore RHCOS failures so we can have nightlies more often without ARTist intervention.