### PR TITLE
[ART-2617] configure for golang-1.19, but use upstream builder

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -434,3 +434,7 @@ csv_namespace: openshift
 check_golang_versions: "no"
 # [2022-09-30 lmeyer] we don't yet have a golang-1.19 for rhel9 so we'll just let it quietly fail
 # for now.
+
+# [2022-09-30] until feature freeze, attempt to use the golang builder that the upstream CI build is
+# using instead of what ART has configured, to encourage them to test before transitioning.
+canonical_builders_from_upstream: true

--- a/images/openshift-enterprise-hyperkube.yml
+++ b/images/openshift-enterprise-hyperkube.yml
@@ -22,7 +22,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: golang-1.19
+  - stream: golang
   member: openshift-enterprise-base
 labels:
   License: GPLv2+

--- a/images/openshift-enterprise-pod.yml
+++ b/images/openshift-enterprise-pod.yml
@@ -18,7 +18,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: golang-1.19
+  - stream: golang
   member: openshift-enterprise-base
 maintainer:
   component: Node

--- a/images/ose-aws-ebs-csi-driver.yml
+++ b/images/ose-aws-ebs-csi-driver.yml
@@ -22,7 +22,7 @@ enabled_repos:
 for_payload: true
 from:
   builder:
-  - stream: golang-1.19
+  - stream: golang
   member: openshift-enterprise-base
 name: openshift/ose-aws-ebs-csi-driver
 owners:

--- a/streams.yml
+++ b/streams.yml
@@ -21,12 +21,13 @@
 
 golang:
   # can be pulled from registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder@...
-  # openshift-golang-builder-container-v1.18.4-202207291631.el8.g2ee6935
-  image: openshift/golang-builder@sha256:66bd53b5f180fb080e164fd97c7aac173ac1a15e7582321f6c0934b39fb50225
+  # [lmeyer 2022-09-15] this is from a scratch build but includes FIPS so could be used for pre-RC builds
+  # openshift-golang-builder-container-v1.19.1-2.beta.scratch.el8.g9480073
+  image: openshift/golang-builder@sha256:95e9d84f48190f79d369bde3dc842ccde029bd3ccd01a5c5a2f1dcdb79616bd8
   mirror: true
   transform: rhel-8/golang
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-{MAJOR}.{MINOR}.art
-  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-{MAJOR}.{MINOR}
+  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}.art
+  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}
 
 rhel-9-golang:
   # can be pulled from registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder@...
@@ -41,22 +42,6 @@ rhel-9-golang:
 # Our transform is designed to create a buildconfig atop a specific golang version, layering on
 # packages that upstream has traditionally had present in its build_roots.
 rhel-8-golang-ci-build-root:
-  image: not_applicable
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-{MAJOR}.{MINOR}
-  transform: rhel-8/ci-build-root
-  upstream_image: registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.18-openshift-{MAJOR}.{MINOR}
-
-golang-1.19:
-  # can be pulled from registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder@...
-  # [lmeyer 2022-09-15] this is from a scratch build but includes FIPS so could be used for pre-RC builds
-  # openshift-golang-builder-container-v1.19.1-2.beta.scratch.el8.g9480073
-  image: openshift/golang-builder@sha256:95e9d84f48190f79d369bde3dc842ccde029bd3ccd01a5c5a2f1dcdb79616bd8
-  mirror: true
-  transform: rhel-8/golang
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}.art
-  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}
-
-rhel-8-golang-1.19-ci-build-root:
   image: not_applicable
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}
   transform: rhel-8/ci-build-root

--- a/streams.yml
+++ b/streams.yml
@@ -21,9 +21,8 @@
 
 golang:
   # can be pulled from registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder@...
-  # [lmeyer 2022-09-15] this is from a scratch build but includes FIPS so could be used for pre-RC builds
-  # openshift-golang-builder-container-v1.19.1-2.beta.scratch.el8.g9480073
-  image: openshift/golang-builder@sha256:95e9d84f48190f79d369bde3dc842ccde029bd3ccd01a5c5a2f1dcdb79616bd8
+  # openshift-golang-builder-container-v1.19.1-202209301544.el8.g1df0bd5
+  image: openshift/golang-builder@sha256:f6232ccbe71b53417ac60a60a84d04f040882e5c539b9a7e2ae21a5c113829fb
   mirror: true
   transform: rhel-8/golang
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}.art


### PR DESCRIPTION
also includes an updated golang-builder 1.19 with a non-scratch golang in it as well as dos2unix installed.

once we get a 4.12 nightly from in-flight content (update: got it with [4.12.0-0.nightly-2022-09-30-200028](https://amd64.ocp.releases.ci.openshift.org/releasestream/4.12.0-0.nightly/release/4.12.0-0.nightly-2022-09-30-200028)), we can merge this which is going to kick off a mass rebuild (even though most will not be changed) and create all those PRs encouraging moving to go 1.19