### PR TITLE
[4.12] couple minor fixes

### DIFF
--- a/images/ose-route-controller-manager.yml
+++ b/images/ose-route-controller-manager.yml
@@ -5,7 +5,7 @@ content:
       branch:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/route-controller-manager.git
-      web: https://github.com/openshift/route-controller-manager 
+      web: https://github.com/openshift/route-controller-manager
     ci_alignment:
       streams_prs:
         ci_build_root:
@@ -13,7 +13,7 @@ content:
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms
-for_payload: false
+for_payload: true
 from:
   builder:
   - stream: golang

--- a/images/ose-sdn.yml
+++ b/images/ose-sdn.yml
@@ -13,8 +13,10 @@ content:
 distgit:
   component: ose-node-container
 enabled_repos:
-- rhel-8-appstream-rpms
 - rhel-8-baseos-rpms
+- rhel-8-appstream-rpms
+# need to use container-selinux from our candidate to match RHCOS:
+- rhel-8-server-ose-rpms-embargoed
 - rhel-8-fast-datapath-rpms
 for_payload: true
 from:


### PR DESCRIPTION
* [ART-4756] route-controller-manager should be in payload (ref. [conversation](https://coreos.slack.com/archives/CB95J6R4N/p1664552031166729))
* reverting the content_set "fix" for ose-sdn, which does in fact need the repo to avoid [inconsistency](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fbuild-sync/27411/artifact/gen-payload-artifacts/assembly-report.yaml/*view*/)