### PR TITLE
Add microshift rpm

### DIFF
--- a/modifications/microshift-rebase
+++ b/modifications/microshift-rebase
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+fail() {
+    msg=$1
+    >&2 echo "$msg"
+    exit 1
+}
+[ -z "$RELEASE_NAME" ] && fail "Environment variable RELEASE_NAME is not set. Note currently rebasing against assembly stream is not supported."
+
+RELEASE_REPO=quay.io/openshift-release-dev/ocp-release
+
+# FIXME: rebase.sh requires Go yq (https://github.com/mikefarah/yq) instead of Python yq (https://github.com/kislyuk/yq),
+# which is used in the rest of the pipeline.
+# We install Go yq to /opt/yq-go/bin/ on buildvm to avoid conflict.
+# In the future we might have to run rebase.sh inside of a container to use specific versions of dependencies (including golang).
+export PATH=/opt/yq-go/bin/:$PATH
+./scripts/rebase.sh to "$RELEASE_REPO":"$RELEASE_NAME"-x86_64 "$RELEASE_REPO":"$RELEASE_NAME"-aarch64

--- a/rpms/microshift.yml
+++ b/rpms/microshift.yml
@@ -1,0 +1,22 @@
+# Disable automated build because it is intended to be built after a release is promoted.
+mode: disabled
+content:
+  source:
+    git:
+      branch:
+        target: main
+        # [lmeyer 2022-07-10] main branch is indeed for 4.10 right now and that is where development is occurring.
+        # We will want this to be release-4.y branches managed by Test Platform once work is beginning on
+        # other releases but that would just get in the way of dev for the current state of affairs.
+      url: git@github.com:openshift/microshift.git
+    specfile: packaging/rpm/microshift.spec
+    modifications:
+    - action: command
+      command: microshift-rebase
+      env:
+        RELEASE_NAME: "{release_name}"
+
+name: microshift
+targets: []
+owners:
+- microshift-devel@redhat.com


### PR DESCRIPTION
microshift has rebased on 4.12.
This rpm is added with `mode: disabled` so that it won't be built during ordinary ART automation.