### PR TITLE
<temp> replace microshift release name template with actual release

### DIFF
--- a/rpms/microshift.yml
+++ b/rpms/microshift.yml
@@ -14,7 +14,7 @@ content:
     - action: command
       command: microshift-rebase
       env:
-        RELEASE_NAME: "{release_name}"
+        RELEASE_NAME: 4.11.8
 
 name: microshift
 targets: []


### PR DESCRIPTION
To prevent this error during promotion:
```
ValueError: /mnt/workspace/jenkins/working/_cd-builds_build_prepare-release@3/artcd_working/elliott-working/ocp-build-data/rpms/microshift.yml contains template key `release_name` but no value was provided
```