### PR TITLE
streams: bump golang builder

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -21,8 +21,8 @@
 
 golang:
   # can be pulled from registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder@...
-  # openshift-golang-builder-container-v1.19.1-202209301544.el8.g1df0bd5
-  image: openshift/golang-builder@sha256:f6232ccbe71b53417ac60a60a84d04f040882e5c539b9a7e2ae21a5c113829fb
+  # openshift-golang-builder-container-v1.19.1-202210051256.el8.g8ad7c79
+  image: openshift/golang-builder@sha256:0be4497fbf34de25143907958475b49e1dddbb8c2b526f3253fb6150ea7bdd71
   mirror: true
   transform: rhel-8/golang
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}.art


### PR DESCRIPTION
The compiler and most content is the same as previous build; but a few RHEL RPMs are reverted back to released versions (previously included some pending releases which caused problems for later layers).

No rush on this, wait for a time when a mass rebuild won't get in the way.