### PR TITLE
Revert "Move 4.6 to osbs2"

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -37,7 +37,6 @@ build_profiles:
       targets:
       - rhaos-{MAJOR}.{MINOR}-rhel-8-candidate
 
-default_image_build_method: osbs2
 default_image_build_profile: unsigned
 default_rpm_build_profile: default
 
@@ -203,6 +202,7 @@ repos:
       # don't have content set for aarch64 or s390x
       optional: true
 
+default_image_build_method: imagebuilder
 image_build_log_scanner:
   matches:
     # yum failed to install a package (but may not give an error result)


### PR DESCRIPTION
Reverts openshift/ocp-build-data#2034

logging-elasticsearch6 image is failing to build. Upstream ticket: https://issues.redhat.com/browse/CLOUDBLD-11234.

Proposing to move 4.6 back to imagebuilder, as 4.6 can stop building before osbs1 cluster is torn down.