### PR TITLE
OSDOCS-4289: shortens the stock text for errata 4.11

### DIFF
--- a/erratatool.yml
+++ b/erratatool.yml
@@ -36,38 +36,30 @@ description: |
 
   https://docs.openshift.com/container-platform/4.11/release_notes/ocp-4-11-release-notes.html
 
-  You may download the oc tool and use it to inspect release image metadata as follows:
-
-      (For x86_64 architecture)
-
-        $ oc adm release info quay.io/openshift-release-dev/ocp-release:4.11.z-x86_64
-
-      The image digest is sha256:<SHASUM_HERE>
-
-      (For s390x architecture)
-
-        $ oc adm release info quay.io/openshift-release-dev/ocp-release:4.11.z-s390x
-
-      The image digest is sha256:<SHASUM_HERE>
-
-      (For ppc64le architecture)
-
-        $ oc adm release info quay.io/openshift-release-dev/ocp-release:4.11.z-ppc64le
-
-      The image digest is sha256:<SHASUM_HERE>
-
-      (For aarch64 architecture)
-
-        $ oc adm release info quay.io/openshift-release-dev/ocp-release:4.11.z-aarch64
-
-      The image digest is sha256:<SHASUM_HERE>
-
-  All OpenShift Container Platform 4.11 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.11/updating/updating-cluster-cli.html
 
 solution: |
   For OpenShift Container Platform 4.11 see the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
 
   https://docs.openshift.com/container-platform/4.11/release_notes/ocp-4-11-release-notes.html
+
+  You may download the oc tool and use it to inspect release image metadata for x86_64, s390x, ppc64le, and aarch64 architectures. The image digests may be found at https://quay.io/repository/openshift-release-dev/ocp-release?tab=tags
+
+  The sha values for the release are:
+
+  (For x86_64 architecture)
+  The image digest is sha256:<SHASUM_HERE>
+
+  (For s390x architecture)
+  The image digest is sha256:<SHASUM_HERE>
+
+  (For ppc64le architecture)
+  The image digest is sha256:<SHASUM_HERE>
+
+  (For aarch64 architecture)
+  The image digest is sha256:<SHASUM_HERE>
+
+  All OpenShift Container Platform 4.11 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.11/updating/updating-cluster-cli.html
+
 
 topic: "Red Hat OpenShift Container Platform release 4.11.z is now available with updates to packages and images that fix several bugs and add enhancements."
 


### PR DESCRIPTION
[OSDOCS-4289](https://issues.redhat.com//browse/OSDOCS-4289): shortens stock text and moves it from the description to the solution.

[Jira](https://issues.redhat.com/browse/OSDOCS-4289) 

Preview

Additional Info:

