### PR TITLE
Freeze automation for 4.11

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -1,4 +1,4 @@
-freeze_automation: false
+freeze_automation: scheduled
 
 vars:
   MAJOR: 4


### PR DESCRIPTION
There are full rebuilds for 4.12 and 4.11 pending while osbs is in outage. Let's ensure 4.12 gets the mass build lock first once builds start flowing.