### PR TITLE
4.12 - set canonical_builders_from_upstream to auto

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -437,4 +437,4 @@ check_golang_versions: "no"
 
 # [2022-09-30] until feature freeze, attempt to use the golang builder that the upstream CI build is
 # using instead of what ART has configured, to encourage them to test before transitioning.
-canonical_builders_from_upstream: true
+canonical_builders_from_upstream: auto


### PR DESCRIPTION
Ref. https://issues.redhat.com/browse/ART-4931

Final step after https://github.com/openshift/doozer/pull/659 and https://github.com/openshift/aos-cd-jobs/pull/3256