### PR TITLE
4.8: Bump etcd golang

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -51,12 +51,12 @@ rhel-8-golang-ci-build-root:
 # approval to diverge from what kube apiserver uses for a given release.
 # https://coreos.slack.com/archives/CB95J6R4N/p1598453188186800?thread_ts=1598449075.172000&cid=CB95J6R4N
 etcd_golang:
-  # openshift-golang-builder-container-v1.12.12-202208020245.el8.ge190075
-  image: openshift/golang-builder@sha256:4b073c102097014a6a3a9c4a51637eb5c52508ee0d0d35c78a5a4736d3862e4f
+  # openshift-golang-builder-container-v1.16.12-202208011952.el8.g58dffad
+  image: openshift/golang-builder@sha256:ca32011a8331e8369f2150e56c39e851dd3e2536a04772eb2577553e6ab380f0
   mirror: true
   # No transform required as etcd does not yum install any packages.
-  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-etcd-golang-1.12
-  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-etcd-golang-1.12
+  upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-etcd-golang-1.16
+  upstream_image: registry.ci.openshift.org/ocp/builder:rhel-8-etcd-golang-1.16
 
 rhel-7-golang:
   # openshift-golang-builder-container-v1.16.12-202208020019.el7.g8382039


### PR DESCRIPTION
Following
https://github.com/openshift/etcd/commit/8af13441b6476d15ecc96bdf58b5ff9ed61fb8a9, golang should be bumped to 1.16.