### PR TITLE
Temporarily pin microshift RPM, just to make prepare-release happy

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -16,6 +16,11 @@ releases:
           rpm: 103659
         release_jira: ART-5046
         upgrades: 4.10.16,4.10.17,4.10.18,4.10.20,4.10.21,4.10.22,4.10.23,4.10.24,4.10.25,4.10.26,4.10.27,4.10.28,4.10.29,4.10.30,4.10.31,4.10.32,4.10.33,4.10.34,4.10.35,4.10.36,4.10.37,4.10.38,4.11.0,4.11.1,4.11.2,4.11.3,4.11.4,4.11.5,4.11.6,4.11.7,4.11.8,4.11.9
+        dependencies:
+          rpms:
+          - el8: microshift-4.10.0-202210041427.p0.gec7afba.assembly.stream.el8
+            why: This build was untagged at the time of brew event, causing prepare-release to search for it, not finding it, and fail.
+            non_gc_tag: rhaos-4.11-rhel-8-hotfix
       members:
         images: []
         rpms: []


### PR DESCRIPTION
Build was untagged at the time of brew event, now elliott tries to find it, but can't, and the job fails :(