### PR TITLE
[4.10] Update rhel-7 golang-builder for goversioninfo rebuild

### DIFF
--- a/streams.yml
+++ b/streams.yml
@@ -61,8 +61,8 @@ etcd_golang:
 
 # This image must only be used by -alt images, as this image cannot be built for aarch64.
 rhel-7-golang:
-  # openshift-golang-builder-container-v1.17.12-202207291742.el7.gf14244d
-  image: openshift/golang-builder@sha256:7c5c79731b51d8df5c4debe2b4cc583a276bf6e7a3f918097eb8371f0ad18daf
+  # openshift-golang-builder-container-v1.17.12-202210242139.el7.gf14244d
+  image: openshift/golang-builder@sha256:71e9e13402bc5662d77dfcadea73fb4dbc4d2f2de51f49332422baaeca240852
   mirror: true
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-7-golang-1.17-openshift-{MAJOR}.{MINOR}.art
   # dptp will layer yum repos / extra packages on top of ART's image to create the


### PR DESCRIPTION
This should fix the cli-artifacts build failures.