### PR TITLE
[4.11] openshift-clients: stop building for rhel7

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -156,24 +156,6 @@ repos:
     reposync:
       latest_only: false
 
-  # The installer team working with rhel-7 worker nodes needs rhel-7 rpms reposync'd.
-  rhel-server-ose-rpms:
-    conf:
-      baseurl:
-        aarch64: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}/building/aarch64/os
-        ppc64le: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}/building/ppc64le/os
-        s390x: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}/building/s390x/os
-        x86_64: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}/building/x86_64/os
-      ci_alignment:
-        profiles:
-        - el7
-        localdev:
-          enabled: true
-    content_set:  # keep empty to avoid being used in ART build or confusing elliott redundant content_set check
-      optional: true
-    reposync:
-      latest_only: false
-
   rhel-8-baseos-rpms:
     conf:
       baseurl:

--- a/rpms/openshift-clients.yml
+++ b/rpms/openshift-clients.yml
@@ -8,11 +8,3 @@ content:
 name: openshift-clients
 owners:
 - aos-master@redhat.com
-distgit:
-  branch: rhaos-{MAJOR}.{MINOR}-rhel-7
-targets:
-- rhaos-{MAJOR}.{MINOR}-rhel-7-candidate  # internal build for ART purposes
-- rhaos-{MAJOR}.{MINOR}-rhel-8-candidate
-hotfix_targets:
-- rhaos-{MAJOR}.{MINOR}-rhel-7-hotfix  # internal build for ART purposes
-- rhaos-{MAJOR}.{MINOR}-rhel-8-hotfix


### PR DESCRIPTION
We don't want to support this against rhel7 and we no longer need to even for internal purposes; statically-linked builds from cross-arch rhel8 compiles will work fine.