### PR TITLE
RNs-4.11-errata: updates errata text for Images

### DIFF
--- a/erratatool.yml
+++ b/erratatool.yml
@@ -78,7 +78,7 @@ boilerplates:
 
       All OpenShift Container Platform 4.11 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.11/updating/updating-cluster-cli.html
     solution: &common_solution |
-      For OpenShift Container Platform 4.11 see the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
+       See the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
 
       https://docs.openshift.com/container-platform/4.11/release_notes/ocp-4-11-release-notes.html
 
@@ -97,34 +97,28 @@ boilerplates:
 
       https://docs.openshift.com/container-platform/4.11/release_notes/ocp-4-11-release-notes.html
 
-      You may download the oc tool and use it to inspect release image metadata as follows:
+    solution: *common_solution |
+      For OpenShift Container Platform 4.11 see the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
 
-          (For x86_64 architecture)
+      https://docs.openshift.com/container-platform/4.11/release_notes/ocp-4-11-release-notes.html
 
-            $ oc adm release info quay.io/openshift-release-dev/ocp-release:4.11.z-x86_64
+      You may download the oc tool and use it to inspect release image metadata for x86_64, s390x, ppc64le, and aarch64 architectures. The image digests may be found at https://quay.io/repository/openshift-release-dev/ocp-release?tab=tags
 
-          The image digest is sha256:<SHASUM_HERE>
+      The sha values for the release are:
 
-          (For s390x architecture)
+      (For x86_64 architecture)
+      The image digest is sha256:<SHASUM_HERE>
 
-            $ oc adm release info quay.io/openshift-release-dev/ocp-release:4.11.z-s390x
+      (For s390x architecture)
+      The image digest is sha256:<SHASUM_HERE>
 
-          The image digest is sha256:<SHASUM_HERE>
+      (For ppc64le architecture)
+      The image digest is sha256:<SHASUM_HERE>
 
-          (For ppc64le architecture)
-
-            $ oc adm release info quay.io/openshift-release-dev/ocp-release:4.11.z-ppc64le
-
-          The image digest is sha256:<SHASUM_HERE>
-
-          (For aarch64 architecture)
-
-            $ oc adm release info quay.io/openshift-release-dev/ocp-release:4.11.z-aarch64
-
-          The image digest is sha256:<SHASUM_HERE>
+      (For aarch64 architecture)
+      The image digest is sha256:<SHASUM_HERE>
 
       All OpenShift Container Platform 4.11 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.11/updating/updating-cluster-cli.html
-    solution: *common_solution
   extras:
     synopsis: OpenShift Container Platform 4.11.z extras update
     topic: *common_topic


### PR DESCRIPTION
This PR is to update the errata text for OCP's RN docs team. Specifically, we are updating the Image advisories `Description` and `Solution` sections. Our goal is to shorten the `Description` section by moving Quay and sha values into the `Solution` section. 

@thiagoalessio and @vfreex this needs cherry picked to 4.10 and 4.12, please. I'll submit a separate PR for 4.8 to be cherrypicked to 4.9. We cannot cherry pick this to 4.8 and 4.9 because  aarch64 architecture is not in that errata text. Thank you

Relates to:
#2094 
#2049 