### PR TITLE
[4.12] Fix arches of PowerVS images

### DIFF
--- a/images/ose-powervs-block-csi-driver-operator.yml
+++ b/images/ose-powervs-block-csi-driver-operator.yml
@@ -1,3 +1,6 @@
+arches:
+- x86_64
+- ppc64le
 content:
   source:
     dockerfile: Dockerfile

--- a/images/ose-powervs-block-csi-driver.yml
+++ b/images/ose-powervs-block-csi-driver.yml
@@ -1,3 +1,6 @@
+arches:
+- x86_64
+- ppc64le
 content:
   source:
     dockerfile: Dockerfile.openshift


### PR DESCRIPTION
The x86 images need to be enabled because of ART-3417.
