### PR TITLE
[4.12 ONLY] Disable GCP images on ARM

### DIFF
--- a/images/ose-gcp-cloud-controller-manager.yml
+++ b/images/ose-gcp-cloud-controller-manager.yml
@@ -1,7 +1,6 @@
 arches:
 - x86_64
 - ppc64le
-- aarch64
 content:
   source:
     git:

--- a/images/ose-gcp-cluster-api-controllers.yml
+++ b/images/ose-gcp-cluster-api-controllers.yml
@@ -1,7 +1,6 @@
 arches:
 - x86_64
 - ppc64le
-- aarch64
 content:
   source:
     dockerfile: openshift/Dockerfile.openshift

--- a/images/ose-gcp-filestore-csi-driver-operator.yml
+++ b/images/ose-gcp-filestore-csi-driver-operator.yml
@@ -1,7 +1,6 @@
 arches:
 - x86_64
 - ppc64le
-- aarch64
 content:
   source:
     dockerfile: Dockerfile.openshift

--- a/images/ose-gcp-filestore-csi-driver.yml
+++ b/images/ose-gcp-filestore-csi-driver.yml
@@ -1,7 +1,6 @@
 arches:
 - x86_64
 - ppc64le
-- aarch64
 content:
   source:
     dockerfile: Dockerfile.openshift

--- a/images/ose-gcp-pd-csi-driver-operator.yml
+++ b/images/ose-gcp-pd-csi-driver-operator.yml
@@ -1,7 +1,6 @@
 arches:
 - x86_64
 - ppc64le
-- aarch64
 content:
   source:
     dockerfile: Dockerfile.openshift

--- a/images/ose-gcp-pd-csi-driver.yml
+++ b/images/ose-gcp-pd-csi-driver.yml
@@ -1,7 +1,6 @@
 arches:
 - x86_64
 - ppc64le
-- aarch64
 content:
   source:
     dockerfile: Dockerfile.openshift

--- a/images/ose-machine-api-provider-gcp.yml
+++ b/images/ose-machine-api-provider-gcp.yml
@@ -1,7 +1,6 @@
 arches:
 - x86_64
 - ppc64le
-- aarch64
 content:
   source:
     dockerfile: Dockerfile.rhel


### PR DESCRIPTION
This is ONLY for 4.12; enablement will continue in 4.13.
