### PR TITLE
temporarily use upstream for ibmcloud-cluster-api-controllers

### DIFF
--- a/images/ose-ibmcloud-cluster-api-controllers.yml
+++ b/images/ose-ibmcloud-cluster-api-controllers.yml
@@ -6,7 +6,7 @@ content:
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
-      url: git@github.com:openshift-priv/cluster-api-provider-ibmcloud.git
+      url: git@github.com:openshift/cluster-api-provider-ibmcloud.git
       web: https://github.com/openshift/cluster-api-provider-ibmcloud.git
     ci_alignment:
       streams_prs:


### PR DESCRIPTION
https://coreos.slack.com/archives/CB95J6R4N/p1667208399070669?thread_ts=1666984321.707159&cid=CB95J6R4N