### PR TITLE
Remove stream permits

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -802,15 +802,3 @@ releases:
             container_yaml!: {}
             cachito:
               enabled: true
-  stream:
-    assembly:
-      type: stream
-      permits:
-      - code: INCONSISTENT_RHCOS_RPMS
-        component: rhcos
-      - code: OUTDATED_RPMS_IN_STREAM_BUILD
-        component: rhcos
-        # why: Pipeline sadness
-      - code: CONFLICTING_GROUP_RPM_INSTALLED
-        component: rhcos
-        # why: Pipeline sadness


### PR DESCRIPTION
We want to remove permanent permits and 
use the emergency ignore issues option to 
run build-sync and get green nightlies