### PR TITLE
disable openshift-client for 4.11

### DIFF
--- a/rpms/openshift-clients.yml
+++ b/rpms/openshift-clients.yml
@@ -1,3 +1,4 @@
+mode: disabled
 content:
   source:
     git:


### PR DESCRIPTION
according to this [thread](https://coreos.slack.com/archives/GDBRP5YJH/p1666965787020509?thread_ts=1666881951.736019&cid=GDBRP5YJH), we don't need openshift-client rpm for 4.11 