### PR TITLE
Fix YAML parsing errors

### DIFF
--- a/erratatool.yml
+++ b/erratatool.yml
@@ -78,7 +78,7 @@ boilerplates:
 
       All OpenShift Container Platform 4.11 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.11/updating/updating-cluster-cli.html
     solution: &common_solution |
-       See the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
+      See the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
 
       https://docs.openshift.com/container-platform/4.11/release_notes/ocp-4-11-release-notes.html
 
@@ -97,7 +97,7 @@ boilerplates:
 
       https://docs.openshift.com/container-platform/4.11/release_notes/ocp-4-11-release-notes.html
 
-    solution: *common_solution |
+    solution: |
       For OpenShift Container Platform 4.11 see the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
 
       https://docs.openshift.com/container-platform/4.11/release_notes/ocp-4-11-release-notes.html


### PR DESCRIPTION
```
yq . <erratatool.yml
yq: Error running jq: ParserError: while parsing a block mapping
  in "<stdin>", line 70, column 5
expected <block end>, but found '<scalar>'
  in "<stdin>", line 83, column 7.
```