### PR TITLE
Clear stream permit comments

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -201,15 +201,3 @@ releases:
             aarch64: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:249b2d423e40b316c9214c85860f633bd9a039e454eb7725e2b6911a3b7eac05
             s390x: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:adddf493fd169fb8b99738487a69e673199533840594ab1a79b7178b82343598
       type: preview
-  stream:
-    assembly:
-      type: stream
-      # permits:
-      # - code: INCONSISTENT_RHCOS_RPMS
-      #   component: 'rhcos'
-      # - code: OUTDATED_RPMS_IN_STREAM_BUILD
-      #   component: 'rhcos'
-      #   # why: ARM builds are failing and we want more nightlies
-      # - code: CONFLICTING_GROUP_RPM_INSTALLED
-      #   component: 'rhcos'
-      #   # why: ARM builds are failing and we want more nightlies


### PR DESCRIPTION
In the future we want to use emergency_ignore_issues
option on build-sync instead of permits, so let's remove
this so one of us doesn't uncomment to get nightlies