### PR TITLE
Enable ppc64le in ibmcloud-cluster-api-controllers

### DIFF
--- a/images/ose-ibmcloud-cluster-api-controllers.yml
+++ b/images/ose-ibmcloud-cluster-api-controllers.yml
@@ -1,5 +1,6 @@
 arches:
 - x86_64
+- ppc64le
 content:
   source:
     dockerfile: openshift/Dockerfile.openshift


### PR DESCRIPTION
Unlike the rest of the IBM Cloud support images, this image is used for both IBM Cloud VPC and PowerVS.

https://coreos.slack.com/archives/CB95J6R4N/p1666984321707159