### PR TITLE
[ART-4858] openshift-enterprise-console: access ocp-artifacts with https

### DIFF
--- a/images/openshift-enterprise-console.yml
+++ b/images/openshift-enterprise-console.yml
@@ -12,9 +12,9 @@ content:
     artifacts:
       from_urls:
       - target: yarn-v1.22.19.tar.gz
-        url: http://ocp-artifacts.hosts.prod.psi.rdu2.redhat.com/pub/RHOCP/build-deps/openshift-enterprise-console/yarn-v1.22.19.tar.gz
+        url: https://ocp-artifacts.hosts.prod.psi.rdu2.redhat.com/pub/RHOCP/build-deps/openshift-enterprise-console/yarn-v1.22.19.tar.gz
         sha256: 732620bac8b1690d507274f025f3c6cfdc3627a84d9642e38a07452cc00e0f2e
-        source-url: http://ocp-artifacts.hosts.prod.psi.rdu2.redhat.com/pub/RHOCP/build-deps/openshift-enterprise-console/yarn-source-v1.22.19.tar.gz
+        source-url: https://ocp-artifacts.hosts.prod.psi.rdu2.redhat.com/pub/RHOCP/build-deps/openshift-enterprise-console/yarn-source-v1.22.19.tar.gz
         source-sha256: 50af0025d2ef942bf3e6cdd0587dc9c4dd8d6e6e69501b84935d09f2b2b5de8b
 cachito:
   enabled: true


### PR DESCRIPTION
we need to access it securely and I [tested that it works|https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fcustom/2790/console].