### PR TITLE
[4.13] Only build ibmcloud-cluster-api-controllers for certain arches

### DIFF
--- a/images/ose-ibmcloud-cluster-api-controllers.yml
+++ b/images/ose-ibmcloud-cluster-api-controllers.yml
@@ -1,3 +1,6 @@
+arches:
+- x86_64
+- ppc64le
 content:
   source:
     dockerfile: openshift/Dockerfile.openshift


### PR DESCRIPTION
Replicating changes made in 4.12 branch (https://github.com/openshift/ocp-build-data/pull/2162)