### PR TITLE
RNs-4.8-errata:updates OCP errata text

### DIFF
--- a/erratatool.yml
+++ b/erratatool.yml
@@ -36,11 +36,11 @@ description: |
   All OpenShift Container Platform 4.8 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.8/updating/updating-cluster-cli.html
 
 solution: |
-  For OpenShift Container Platform 4.8 see the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
+  See the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
 
   https://docs.openshift.com/container-platform/4.8/release_notes/ocp-4-8-release-notes.html
 
-   You may download the oc tool and use it to inspect release image metadata for x86_64, s390x, ppc64le, and aarch64 architectures.
+   You may download the oc tool and use it to inspect release image metadata for x86_64, s390x, and ppc64le architectures.
 
    The image digests may be found at https://quay.io/repository/openshift-release-dev/ocp-release?tab=tags
 
@@ -55,7 +55,7 @@ solution: |
   (For ppc64le architecture)
   The image digest is sha256:<SHASUM_HERE>
 
-  All OpenShift Container Platform 4.8 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.11/updating/updating-cluster-cli.html
+  All OpenShift Container Platform 4.8 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.8/updating/updating-cluster-cli.html
 
 topic: "Red Hat OpenShift Container Platform release 4.8.z is now available with updates to packages and images that fix several bugs and add enhancements."
 
@@ -93,28 +93,28 @@ boilerplates:
 
       https://docs.openshift.com/container-platform/4.8/release_notes/ocp-4-8-release-notes.html
 
-      You may download the oc tool and use it to inspect release image metadata as follows:
+      All OpenShift Container Platform 4.8 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.8/updating/updating-cluster-cli.html
+    solution: &common_solution |
+      See the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
 
-          (For x86_64 architecture)
+      https://docs.openshift.com/container-platform/4.8/release_notes/ocp-4-8-release-notes.html
 
-            $ oc adm release info quay.io/openshift-release-dev/ocp-release:4.8.z-x86_64
+      You may download the oc tool and use it to inspect release image metadata for x86_64, s390x, and ppc64le architectures.
 
-          The image digest is sha256:<SHASUM_HERE>
+      The image digests may be found at https://quay.io/repository/openshift-release-dev/ocp-release?tab=tags
 
-          (For s390x architecture)
+      The sha values for the release are:
 
-            $ oc adm release info quay.io/openshift-release-dev/ocp-release:4.8.z-s390x
+      (For x86_64 architecture)
+      The image digest is sha256:<SHASUM_HERE>
 
-          The image digest is sha256:<SHASUM_HERE>
+      (For s390x architecture)
+      The image digest is sha256:<SHASUM_HERE>
 
-          (For ppc64le architecture)
-
-            $ oc adm release info quay.io/openshift-release-dev/ocp-release:4.8.z-ppc64le
-
-          The image digest is sha256:<SHASUM_HERE>
+      (For ppc64le architecture)
+      The image digest is sha256:<SHASUM_HERE>
 
       All OpenShift Container Platform 4.8 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.8/updating/updating-cluster-cli.html
-    solution: *common_solution
   extras:
     synopsis: OpenShift Container Platform 4.8.z extras update
     topic: *common_topic


### PR DESCRIPTION
Updates errata text for 4.8 by moving SHAs and quay to the solutions section. The move leave more room in the description section for bugs.

PTAL @thiagoalessio and @opayne1 