### PR TITLE
ose-tests: fix too many open files error

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -70,12 +70,6 @@ push:
   registries: []
     # - quay.io/openshift-qe-optional-operators
 
-sources:
-  ose:
-    url: git@github.com:openshift-priv/origin.git
-    branch:
-      target: release-{MAJOR}.{MINOR}
-
 public_upstreams:
 - private: "https://github.com/openshift-priv"
   public: "https://github.com/openshift"

--- a/images/openshift-enterprise-tests.yml
+++ b/images/openshift-enterprise-tests.yml
@@ -1,7 +1,15 @@
 content:
   source:
-    alias: ose
+    git:
+      branch:
+        target: release-{MAJOR}.{MINOR}
+      url: git@github.com:openshift-priv/origin.git
+      web: https://github.com/openshift/origin
     dockerfile: images/tests/Dockerfile.rhel
+    modifications:
+    - action: replace
+      match: "COPY . ."
+      replacement: "COPY . .\nRUN rm -rf unpacked_remote_sources"  # FIXME: Workaround for CLOUDBLD-8974
     ci_alignment:
       streams_prs:
         ci_build_root:


### PR DESCRIPTION
This seems to be caused by the same issue as CLOUDBLD-8974. Test build succeeded: https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fcustom/2795/console

Also deprecate the use of global source. That feature is considered deprecated and we now only have one image built from that repo.