### PR TITLE
OCP-4.13 - add permits to let nightlies start flowing

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -63,6 +63,12 @@ urls:
   brew_image_host: registry-proxy.engineering.redhat.com
   brew_image_namespace: rh-osbs
   cgit: http://pkgs.devel.redhat.com/cgit
+  # temporarily point at 4.12 until 4.10 RHCOS gets rolling
+  rhcos_release_base:
+    x86_64: https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/releases/rhcos-4.12
+    s390x: https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/releases/rhcos-4.12-s390x
+    ppc64le: https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/releases/rhcos-4.12-ppc64le
+    aarch64: https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/releases/rhcos-4.12-aarch64
 dist_git_ignore:
   - gating.yaml
 

--- a/releases.yml
+++ b/releases.yml
@@ -1,1 +1,11 @@
-releases: {}
+releases:
+  stream:
+    assembly:
+      type: stream
+      permits:
+      - code: INCONSISTENT_RHCOS_RPMS
+        component: 'rhcos'
+      - code: OUTDATED_RPMS_IN_STREAM_BUILD
+        component: 'rhcos'
+      - code: CONFLICTING_GROUP_RPM_INSTALLED
+        component: 'rhcos'


### PR DESCRIPTION
This PR temporarily pins 4.12 rhcos and adds permits to stream assembly to let nightlies production start.