### PR TITLE
Disable openshift-clients rhel9 targets

### DIFF
--- a/rpms/openshift-clients.yml
+++ b/rpms/openshift-clients.yml
@@ -10,7 +10,7 @@ owners:
 - aos-master@redhat.com
 targets:
 - rhaos-{MAJOR}.{MINOR}-rhel-8-candidate
-- rhaos-{MAJOR}.{MINOR}-rhel-9-candidate
+# - rhaos-{MAJOR}.{MINOR}-rhel-9-candidate
 hotfix_targets:
 - rhaos-{MAJOR}.{MINOR}-rhel-8-hotfix
-- rhaos-{MAJOR}.{MINOR}-rhel-9-hotfix
+# - rhaos-{MAJOR}.{MINOR}-rhel-9-hotfix


### PR DESCRIPTION
[4.13 build-sync](https://saml.buildvm.openshift.eng.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fbuild-sync/28326/console) is breaking with:
```
OSError: RPM openshift-clients claims to have a rhel-9 build target, but not build was detected
```