### PR TITLE
[4.12] Permit rhcos because p8 is broken

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -210,12 +210,12 @@ releases:
   stream:
     assembly:
       type: stream
-      # permits:
-      # - code: INCONSISTENT_RHCOS_RPMS
-      #   component: 'rhcos'
-      # - code: OUTDATED_RPMS_IN_STREAM_BUILD
-      #   component: 'rhcos'
-      #   # why: ARM builds are failing and we want more nightlies
-      # - code: CONFLICTING_GROUP_RPM_INSTALLED
-      #   component: 'rhcos'
-      #   # why: ARM builds are failing and we want more nightlies
+      permits:
+      - code: INCONSISTENT_RHCOS_RPMS
+        component: 'rhcos'
+      - code: OUTDATED_RPMS_IN_STREAM_BUILD
+        component: 'rhcos'
+        # why: p8 builds are failing and we want more nightlies
+      - code: CONFLICTING_GROUP_RPM_INSTALLED
+        component: 'rhcos'
+        # why: p8 builds are failing and we want more nightlies


### PR DESCRIPTION
https://coreos.slack.com/archives/CB95J6R4N/p1668002087089749
This should be reverted as soon as the problem is fixed