### PR TITLE
4.13: permit openvswitch outdatedness

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -9,6 +9,10 @@ releases:
         component: 'rhcos'
       - code: CONFLICTING_GROUP_RPM_INSTALLED
         component: 'rhcos'
+      - code: OUTDATED_RPMS_IN_STREAM_BUILD
+        component: ose-ovn-kubernetes
+      - code: OUTDATED_RPMS_IN_STREAM_BUILD
+        component: ovn-kubernetes-microshift
       members:
         images:
         - distgit_key: openshift-enterprise-console


### PR DESCRIPTION
Need this until pinned rpms are updated https://github.com/openshift/ovn-kubernetes/pull/1362
also see: https://coreos.slack.com/archives/C048BG69N8H/p1668031797575059