### PR TITLE
[4.13] Permit outdated rpms

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -5,8 +5,6 @@ releases:
       permits:
       - code: INCONSISTENT_RHCOS_RPMS
         component: 'rhcos'
-      - code: OUTDATED_RPMS_IN_STREAM_BUILD
-        component: 'rhcos'
       - code: CONFLICTING_GROUP_RPM_INSTALLED
         component: 'rhcos'
       - code: OUTDATED_RPMS_IN_STREAM_BUILD

--- a/releases.yml
+++ b/releases.yml
@@ -10,9 +10,7 @@ releases:
       - code: CONFLICTING_GROUP_RPM_INSTALLED
         component: 'rhcos'
       - code: OUTDATED_RPMS_IN_STREAM_BUILD
-        component: ose-ovn-kubernetes
-      - code: OUTDATED_RPMS_IN_STREAM_BUILD
-        component: ovn-kubernetes-microshift
+        component: '*'
       members:
         images:
         - distgit_key: openshift-enterprise-console


### PR DESCRIPTION
This is the default for all stream assemblies so we should keep this
from stopping our nightlies
https://github.com/openshift/doozer/blob/a7fc1984673fdcc9bbf9d0fc12a71cfe270a6649/doozerlib/assembly.py#L298

