### PR TITLE
[4.12] Permit outdated rpms

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -213,9 +213,10 @@ releases:
       permits:
       - code: INCONSISTENT_RHCOS_RPMS
         component: 'rhcos'
+      # why: p8 builds are failing and we want more nightlies
       - code: OUTDATED_RPMS_IN_STREAM_BUILD
-        component: 'rhcos'
-        # why: p8 builds are failing and we want more nightlies
+        component: '*'
+      # why: default permit
       - code: CONFLICTING_GROUP_RPM_INSTALLED
         component: 'rhcos'
-        # why: p8 builds are failing and we want more nightlies
+      # why: default permit


### PR DESCRIPTION
This is the default for all stream assemblies so we should keep this
from stopping our nightlies
https://github.com/openshift/doozer/blob/a7fc1984673fdcc9bbf9d0fc12a71cfe270a6649/doozerlib/assembly.py#L298