### PR TITLE
Unpin console

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -9,10 +9,3 @@ releases:
         component: 'rhcos'
       - code: OUTDATED_RPMS_IN_STREAM_BUILD
         component: '*'
-      members:
-        images:
-        - distgit_key: openshift-enterprise-console
-          metadata:
-            is:
-              nvr: openshift-enterprise-console-container-v4.12.0-202211072124.p0.gf854c48.assembly.stream
-          why: Need a console image in the payload for payload to not fail until build failure gets worked out


### PR DESCRIPTION
4.13 builds are back (most recent one [here](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2256388)). 