### PR TITLE
[3.11] Update plashet repo URLs

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -128,8 +128,8 @@ repos:
   rhel-server-ose-rpms:
     conf:
       baseurl:
-        ppc64le: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}/building/ppc64le/os
-        x86_64: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}/building/x86_64/os
+        ppc64le: https://ocp-artifacts.hosts.prod.psi.rdu2.redhat.com/pub/RHOCP/plashets/{MAJOR}.{MINOR}/building/ppc64le/os
+        x86_64: https://ocp-artifacts.hosts.prod.psi.rdu2.redhat.com/pub/RHOCP/plashets/{MAJOR}.{MINOR}/building/x86_64/os
     content_set:
       default: rhel-7-server-ose-{MAJOR}.{MINOR}-rpms
       optional: true
@@ -137,8 +137,8 @@ repos:
   rhel-server-ose-rpms-embargoed:
     conf:
       baseurl:
-        ppc64le: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}/building-embargoed/ppc64le/os
-        x86_64: http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}/building-embargoed/x86_64/os
+        ppc64le: https://ocp-artifacts.hosts.prod.psi.rdu2.redhat.com/pub/RHOCP/plashets/{MAJOR}.{MINOR}/building-embargoed/ppc64le/os
+        x86_64: https://ocp-artifacts.hosts.prod.psi.rdu2.redhat.com/pub/RHOCP/plashets/{MAJOR}.{MINOR}/building-embargoed/x86_64/os
     content_set:
       default: rhel-7-server-ose-{MAJOR}.{MINOR}-rpms
       optional: true


### PR DESCRIPTION
Plashet repos have been moved to ocp-artifacts.

/hold the PR for creating the repo is not created yet.