### PR TITLE
Revert "Remove nutanix-cloud-controller-manager image (#2161)"

### DIFF
--- a/images/ose-nutanix-cloud-controller-manager.yml
+++ b/images/ose-nutanix-cloud-controller-manager.yml
@@ -1,0 +1,24 @@
+arches:
+- x86_64
+content:
+  source:
+    git:
+      url: git@github.com:openshift-priv/cloud-provider-nutanix.git
+      web: https://github.com/openshift/cloud-provider-nutanix.git
+      branch:
+        target: release-{MAJOR}.{MINOR}
+    dockerfile: openshift/Dockerfile.openshift
+enabled_repos:
+- rhel-8-baseos-rpms
+- rhel-8-appstream-rpms
+for_payload: true
+from:
+  builder:
+  - stream: golang
+  member: openshift-enterprise-base
+name: openshift/ose-nutanix-cloud-controller-manager
+owners:
+- mfedosin@redhat.com
+- jspeed@redhat.com
+- elmiko@redhat.com
+- dmoiseev@redhat.com


### PR DESCRIPTION
Per https://issues.redhat.com/browse/ART-5201 we want this to remain in 4.13

This reverts commit 7e106b621262b35d103131e721ec08a29e2862eb.