### PR TITLE
update etcd alignment build root

### DIFF
--- a/images/ose-etcd.yml
+++ b/images/ose-etcd.yml
@@ -11,7 +11,7 @@ content:
     ci_alignment:
       streams_prs:
         ci_build_root:
-          stream: rhel-8-golang-ci-build-root
+          stream: etcd_golang
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms


### PR DESCRIPTION
etcd will keep their build root in go 1.16, no need to create alignment pr for 1.19