### PR TITLE
OCPCLOUD-1785: Update commit prefixes for cluster infra team forks

### DIFF
--- a/images/atomic-openshift-cluster-autoscaler.yml
+++ b/images/atomic-openshift-cluster-autoscaler.yml
@@ -8,6 +8,7 @@ content:
       web: https://github.com/openshift/kubernetes-autoscaler
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
 distgit:

--- a/images/ose-alibaba-cloud-controller-manager.yml
+++ b/images/ose-alibaba-cloud-controller-manager.yml
@@ -8,6 +8,11 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cloud-provider-alibaba-cloud.git
       web: https://github.com/openshift/cloud-provider-alibaba-cloud
+    ci_alignment:
+      streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
+        ci_build_root:
+          stream: rhel-8-golang-ci-build-root
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms

--- a/images/ose-aws-cluster-api-controllers.yml
+++ b/images/ose-aws-cluster-api-controllers.yml
@@ -9,6 +9,11 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-api-provider-aws.git
       web: https://github.com/openshift/cluster-api-provider-aws
+    ci_alignment:
+      streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
+        ci_build_root:
+          stream: rhel-8-golang-ci-build-root
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms

--- a/images/ose-azure-cluster-api-controllers.yml
+++ b/images/ose-azure-cluster-api-controllers.yml
@@ -9,6 +9,11 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-api-provider-azure.git
       web: https://github.com/openshift/cluster-api-provider-azure
+    ci_alignment:
+      streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
+        ci_build_root:
+          stream: rhel-8-golang-ci-build-root
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms

--- a/images/ose-cluster-api.yml
+++ b/images/ose-cluster-api.yml
@@ -6,6 +6,11 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-api.git
       web: https://github.com/openshift/cluster-api
+    ci_alignment:
+      streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
+        ci_build_root:
+          stream: rhel-8-golang-ci-build-root
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms

--- a/images/ose-cluster-kube-cluster-api-operator.yml
+++ b/images/ose-cluster-kube-cluster-api-operator.yml
@@ -6,6 +6,11 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-api-operator.git
       web: https://github.com/openshift/cluster-api-operator
+    ci_alignment:
+      streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
+        ci_build_root:
+          stream: rhel-8-golang-ci-build-root
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms

--- a/images/ose-gcp-cloud-controller-manager.yml
+++ b/images/ose-gcp-cloud-controller-manager.yml
@@ -10,6 +10,11 @@ content:
       branch:
         target: release-{MAJOR}.{MINOR}
     dockerfile: openshift-hack/images/Dockerfile.openshift
+    ci_alignment:
+      streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
+        ci_build_root:
+          stream: rhel-8-golang-ci-build-root
 name: openshift/ose-gcp-cloud-controller-manager
 for_payload: true
 owners:

--- a/images/ose-gcp-cluster-api-controllers.yml
+++ b/images/ose-gcp-cluster-api-controllers.yml
@@ -10,6 +10,11 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-api-provider-gcp.git
       web: https://github.com/openshift/cluster-api-provider-gcp
+    ci_alignment:
+      streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
+        ci_build_root:
+          stream: rhel-8-golang-ci-build-root
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms

--- a/images/ose-ibmcloud-machine-controllers.yml
+++ b/images/ose-ibmcloud-machine-controllers.yml
@@ -10,7 +10,6 @@ content:
       web: https://github.com/openshift/machine-api-provider-ibmcloud
     ci_alignment:
       streams_prs:
-        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
 enabled_repos:

--- a/images/ose-kubevirt-cloud-controller-manager.yml
+++ b/images/ose-kubevirt-cloud-controller-manager.yml
@@ -8,6 +8,7 @@ content:
       web: https://github.com/openshift/cloud-provider-kubevirt
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
         auto_label:

--- a/images/ose-machine-api-provider-aws.yml
+++ b/images/ose-machine-api-provider-aws.yml
@@ -11,7 +11,6 @@ content:
       web: https://github.com/openshift/machine-api-provider-aws
     ci_alignment:
       streams_prs:
-        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
 enabled_repos:

--- a/images/ose-machine-api-provider-azure.yml
+++ b/images/ose-machine-api-provider-azure.yml
@@ -11,7 +11,6 @@ content:
       web: https://github.com/openshift/machine-api-provider-azure
     ci_alignment:
       streams_prs:
-        commit_prefix: "UPSTREAM: <carry>: openshift: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
 enabled_repos:

--- a/images/ose-ovirt-machine-controllers.yml
+++ b/images/ose-ovirt-machine-controllers.yml
@@ -8,6 +8,7 @@ content:
       web: https://github.com/openshift/cluster-api-provider-ovirt
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
 enabled_repos:

--- a/images/ose-powervs-cloud-controller-manager.yml
+++ b/images/ose-powervs-cloud-controller-manager.yml
@@ -11,6 +11,7 @@ content:
       web: https://github.com/openshift/cloud-provider-powervs
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
 distgit:

--- a/images/ose-vsphere-cloud-controller-manager.yml
+++ b/images/ose-vsphere-cloud-controller-manager.yml
@@ -8,6 +8,11 @@ content:
       branch:
         target: release-{MAJOR}.{MINOR}
     dockerfile: openshift-hack/images/cloud-controller-manager-openshift.Dockerfile
+    ci_alignment:
+      streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
+        ci_build_root:
+          stream: rhel-8-golang-ci-build-root
 name: openshift/ose-vsphere-cloud-controller-manager
 for_payload: true
 owners:

--- a/images/ose-vsphere-cluster-api-controllers.yml
+++ b/images/ose-vsphere-cluster-api-controllers.yml
@@ -8,6 +8,11 @@ content:
         target: release-{MAJOR}.{MINOR}
       url: git@github.com:openshift-priv/cluster-api-provider-vsphere.git
       web: https://github.com/openshift/cluster-api-provider-vsphere
+    ci_alignment:
+      streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
+        ci_build_root:
+          stream: rhel-8-golang-ci-build-root
 enabled_repos:
 - rhel-8-baseos-rpms
 - rhel-8-appstream-rpms

--- a/images/vertical-pod-autoscaler.yml
+++ b/images/vertical-pod-autoscaler.yml
@@ -9,6 +9,7 @@ content:
     path: vertical-pod-autoscaler
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
 ## [dpaolell] disabled until upstream is configured for 4.13


### PR DESCRIPTION
Currently we plan to use [rebasebot](https://github.com/openshift-eng/rebasebot) for all our forks, so we need to update commit prefixes accordingly.

This commit adds the prefix for all cluster team forks and removes unnecessary ones.