### PR TITLE
[4.13] Enable multi rhcos builds

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -64,7 +64,7 @@ urls:
   brew_image_namespace: rh-osbs
   cgit: http://pkgs.devel.redhat.com/cgit
   rhcos_release_base:
-    multi: https://s3.amazonaws.com/rhcos-ci/prod/streams/{MAJOR}.{MINOR}/builds
+    multi: https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/prod/streams/{MAJOR}.{MINOR}/builds
 dist_git_ignore:
   - gating.yaml
 

--- a/group.yml
+++ b/group.yml
@@ -63,12 +63,8 @@ urls:
   brew_image_host: registry-proxy.engineering.redhat.com
   brew_image_namespace: rh-osbs
   cgit: http://pkgs.devel.redhat.com/cgit
-  # temporarily point at 4.12 until 4.10 RHCOS gets rolling
   rhcos_release_base:
-    x86_64: https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/releases/rhcos-4.12
-    s390x: https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/releases/rhcos-4.12-s390x
-    ppc64le: https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/releases/rhcos-4.12-ppc64le
-    aarch64: https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/releases/rhcos-4.12-aarch64
+    multi: https://s3.amazonaws.com/rhcos-ci/prod/streams/{MAJOR}.{MINOR}/builds
 dist_git_ignore:
   - gating.yaml
 


### PR DESCRIPTION
To test if we're ready to merge this in run
```
doozer --group openshift-4.13@art_5258_413 --data-path https://github.com/thegreyd/ocp-build-data inspect:stream INCONSISTENT_RHCOS_RPMS
...
RHCOS builds consistent [RHCOSBuild:x86_64:413.86.202211232309-0, RHCOSBuild:ppc64le:413.86.202211232309-0, RHCOSBuild:s390x:413.86.202211232309-0, RHCOSBuild:aarch64:413.86.202211232309-0]
```



