### PR TITLE
4.9.53 Exclude already shipped tracker - 2

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -20,6 +20,8 @@ releases:
         exclude:
         - id: OCPBUGS-1220
           # Fix was shipped in 4.9.52
+        - id: 2114759
+          # Fix was shipped in 4.9.52
       members:
         images: []
         rpms: []


### PR DESCRIPTION
Similar case to https://github.com/openshift/ocp-build-data/pull/2309
https://bugzilla.redhat.com/show_bug.cgi?id=2114759

Fixed in https://github.com/openshift/jenkins/pull/1481
Build request: https://issues.redhat.com/browse/ART-5202
plugins build ^ was shipped as part of 4.9.52 https://errata.devel.redhat.com/advisory/105543