### PR TITLE
Revert "[4.13] Enable multi rhcos builds (#2288)"

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -63,8 +63,12 @@ urls:
   brew_image_host: registry-proxy.engineering.redhat.com
   brew_image_namespace: rh-osbs
   cgit: http://pkgs.devel.redhat.com/cgit
+  # temporarily point at 4.12 until 4.13 RHCOS gets rolling
   rhcos_release_base:
-    multi: https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/prod/streams/{MAJOR}.{MINOR}/builds
+    x86_64: https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/releases/rhcos-4.12
+    s390x: https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/releases/rhcos-4.12-s390x
+    ppc64le: https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/releases/rhcos-4.12-ppc64le
+    aarch64: https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/releases/rhcos-4.12-aarch64
 dist_git_ignore:
   - gating.yaml
 


### PR DESCRIPTION
Problems with the current multi pipeline prevent nightlies.

This reverts commit 6fae0cde0d6eed24e2bd87607265e2c6aad5c1de.