### PR TITLE
Revert "Revert "[4.13] Enable multi rhcos builds (#2288)""

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -63,12 +63,8 @@ urls:
   brew_image_host: registry-proxy.engineering.redhat.com
   brew_image_namespace: rh-osbs
   cgit: http://pkgs.devel.redhat.com/cgit
-  # temporarily point at 4.12 until 4.13 RHCOS gets rolling
   rhcos_release_base:
-    x86_64: https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/releases/rhcos-4.12
-    s390x: https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/releases/rhcos-4.12-s390x
-    ppc64le: https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/releases/rhcos-4.12-ppc64le
-    aarch64: https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/releases/rhcos-4.12-aarch64
+    multi: https://releases-rhcos-art.apps.ocp-virt.prod.psi.redhat.com/storage/prod/streams/{MAJOR}.{MINOR}/builds
 dist_git_ignore:
   - gating.yaml
 


### PR DESCRIPTION
This reverts commit ac1fabd0e7bf429cf32b847c5621a57b2c7d0339.

Problem with quoted label fixed, [test job](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/aos-cd-builds/job/build%252Fbuild-sync/28847/console) with prior commit succeeded in creating a [multi nightly](https://multi.ocp.releases.ci.openshift.org/releasestream/4.13.0-0.nightly-multi/release/4.13.0-0.nightly-multi-2022-12-02-042401) and [p8 nightly](https://ppc64le.ocp.releases.ci.openshift.org/releasestream/4.13.0-0.nightly-ppc64le/release/4.13.0-0.nightly-ppc64le-2022-12-02-042255).