### PR TITLE
cluster-node-tuning: Fix declared base images

### DIFF
--- a/images/cluster-node-tuning-operator.yml
+++ b/images/cluster-node-tuning-operator.yml
@@ -20,7 +20,6 @@ for_payload: true
 from:
   builder:
   - stream: golang
-  - member: openshift-base-rhel8
   member: openshift-enterprise-base
 name: openshift/ose-cluster-node-tuning-operator
 owners:


### PR DESCRIPTION
To match upstream dockerfile after https://github.com/openshift/cluster-node-tuning-operator/pull/519