### PR TITLE
WiP: [4.13] Switch NTO to use RHEL-9 payload

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -315,6 +315,27 @@ repos:
     reposync:
       enabled: false
 
+  rhel-9-fast-datapath-rpms:
+    conf:
+      baseurl:
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/x86_64/fast-datapath/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/ppc64le/fast-datapath/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/s390x/fast-datapath/os/
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/aarch64/fast-datapath/os/
+      ci_alignment:
+        profiles:
+        - el9
+        localdev:
+          enabled: true
+    content_set:
+      default: fast-datapath-for-rhel-9-x86_64-rpms
+      aarch64: fast-datapath-for-rhel-9-aarch64-rpms
+      ppc64le: fast-datapath-for-rhel-9-ppc64le-rpms
+      s390x: fast-datapath-for-rhel-9-s390x-rpms
+      optional: true
+    reposync:
+      enabled: false
+
   rhel-9-server-ose-rpms-embargoed:
     conf:
       extra_options:

--- a/images/cluster-node-tuning-operator.yml
+++ b/images/cluster-node-tuning-operator.yml
@@ -1,6 +1,6 @@
 content:
   source:
-    dockerfile: Dockerfile.rhel8
+    dockerfile: Dockerfile.rhel9
     git:
       branch:
         target: release-{MAJOR}.{MINOR}
@@ -13,9 +13,9 @@ content:
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
 enabled_repos:
-- rhel-8-baseos-rpms
-- rhel-8-appstream-rpms
-- rhel-8-fast-datapath-rpms
+- rhel-9-baseos-rpms
+- rhel-9-appstream-rpms
+- rhel-9-fast-datapath-rpms
 for_payload: true
 from:
   builder:


### PR DESCRIPTION
Changes:
  - added [RHEL-9](https://issues.redhat.com//browse/RHEL-9) FDP repo
  - use [RHEL-9](https://issues.redhat.com//browse/RHEL-9) Containerfile for NTO
  - use [RHEL-9](https://issues.redhat.com//browse/RHEL-9) baseos/appstream/FDP repos for NTO