### PR TITLE
Revert "releases: pin python-twisted for ironic"

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -1629,9 +1629,3 @@ releases:
       - code: CONFLICTING_GROUP_RPM_INSTALLED
         component: 'rhcos'
       # why: default permit
-      group:
-        dependencies:
-          rpms:
-          - why: CLOUDBLD-12620 ironic needs an updated RPM but not updated repos
-            non_gc_tag: rhos-16.1-rhel-8
-            el8: python-twisted-16.4.1-20.el8ost


### PR DESCRIPTION
The package is now tagged in our buildroot.

This reverts commit 473f9a96ceefbc4ded72020500e0baa4f3e75f6a.