### PR TITLE
ovn-kubernetes: Inherit from base image

### DIFF
--- a/images/ose-ovn-kubernetes.yml
+++ b/images/ose-ovn-kubernetes.yml
@@ -19,7 +19,7 @@ from:
   builder:
   - stream: golang
   - member: openshift-enterprise-cli
-  member: openshift-enterprise-base
+  member: ovn-kubernetes-base
 labels:
   License: GPLv2+
   io.k8s.description: This is a component of OpenShift Container Platform that provides

--- a/images/ovn-kubernetes-base.yml
+++ b/images/ovn-kubernetes-base.yml
@@ -11,14 +11,12 @@ content:
       streams_prs:
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
-## [dpaolell] disabled until upstream is configured for 4.13
-#dependents:
-#- ovn-kubernetes-microshift
 distgit:
   component: ose-ovn-kubernetes-base-container
 enabled_repos:
 - rhel-8-appstream-rpms
 - rhel-8-baseos-rpms
+- rhel-8-server-ose-rpms-embargoed
 for_payload: false
 for_release: false
 from:


### PR DESCRIPTION
Since https://github.com/openshift/ovn-kubernetes/pull/1239 merged:
- rpms get installed in the base image, need to add ose repo
- ovn-kubernetes uses the base image as base for its final layer