### PR TITLE
Prepare 4.11.20

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -1,4 +1,10 @@
 releases:
+  4.11.20:
+    assembly:
+      basis:
+        assembly: 4.11.19
+        # bump because of missed tracker bug and rhba->rhsa advisory url fix
+      type: standard
   4.11.19:
     assembly:
       basis:


### PR DESCRIPTION
We missed a cve tracker so this is to bump the version
so we can fix the advisory url

https://saml.buildvm.openshift.eng.bos.redhat.com:8888/view/Build%204.x/job/aos-cd-builds/job/build%252Fbuild-sync/29127/console