### PR TITLE
prep for RC

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -413,10 +413,7 @@ csv_namespace: openshift
 
 # whether and how to check if all buildroots have consistent versions of golang compilers (rpm build only)
 # "x.y" (default): only major and minor version; "exact": the z-version must be the same; "no": do not check
-check_golang_versions: "no"
-# [2022-09-30 lmeyer] we don't yet have a golang-1.19 for rhel9 so we'll just let it quietly fail
-# for now.
+check_golang_versions: "x.y"
+# [2023-01-04 lmeyer] golang-1.19 is a bit behind for rhel9
 
-# [2022-09-30] until feature freeze, attempt to use the golang builder that the upstream CI build is
-# using instead of what ART has configured, to encourage them to test before transitioning.
-canonical_builders_from_upstream: auto
+canonical_builders_from_upstream: no

--- a/releases.yml
+++ b/releases.yml
@@ -603,15 +603,15 @@ releases:
       group:
         dependencies:
           rpms:
-          - why: Bugfix, not shipping until the new year
+          - why: Bugfix, not shipping just yet
             non_gc_tag: rhel-8.6.0-z
-            el8: kernel-4.18.0-372.39.1.el8_6
+            el8: kernel-4.18.0-372.40.1.el8_6
+          - why: See RHELWF-8001 and RHELDST-14877 -- kernel-rt 8.6 (we ship)
+            non_gc_tag: rhaos-4.12-rhel-8
+            el8: kernel-rt-4.18.0-372.40.1.rt7.197.el8_6
           - why: See RHELWF-8001 and RHELDST-14877 -- kernel-rt dep from 8.7
             non_gc_tag: rhel-8.6.0-z
             el8: rt-setup-2.1-4.el8
-          - why: See RHELWF-8001 and RHELDST-14877 -- kernel-rt 8.6 (we ship)
-            non_gc_tag: rhaos-4.12-rhel-8
-            el8: kernel-rt-4.18.0-372.39.1.rt7.196.el8_6
       members:
         images:
         - distgit_key: driver-toolkit

--- a/streams.yml
+++ b/streams.yml
@@ -21,8 +21,8 @@
 
 golang:
   # can be pulled from registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder@...
-  # openshift-golang-builder-container-v1.19.2-202210201317.el8.g9b471e1
-  image: openshift/golang-builder@sha256:375f81a15a5217301fc72aaedbe86c063952967af6b56348db20a5c3bbd5995d
+  # openshift-golang-builder-container-v1.19.4-202301042245.el8.g1832cfe
+  image: openshift/golang-builder@sha256:d027750cda93ab497afbde0e09ef3d12e0aac10e9c89ed6da866b15188c9969c
   mirror: true
   transform: rhel-8/golang
   upstream_image_base: registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-{MAJOR}.{MINOR}.art


### PR DESCRIPTION
- update golang-builder to fix leak
- pin latest kernels