### PR TITLE
USHIFT-614: update branch for microshift rpmbuild

### DIFF
--- a/rpms/microshift.yml
+++ b/rpms/microshift.yml
@@ -4,10 +4,7 @@ content:
   source:
     git:
       branch:
-        target: main
-        # [lmeyer 2022-07-10] main branch is indeed for 4.10 right now and that is where development is occurring.
-        # We will want this to be release-4.y branches managed by Test Platform once work is beginning on
-        # other releases but that would just get in the way of dev for the current state of affairs.
+        target: release-4.12
       url: git@github.com:openshift/microshift.git
     specfile: packaging/rpm/microshift.spec
     modifications:


### PR DESCRIPTION
Now that the release-4.12 branch exists, update the build config to use that instead of main when building the MicroShift RPM.

/cc @sosiouxme 