### PR TITLE
group.yml: sync rhel-9-fast-datapath-rpms for use in SDN

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -382,6 +382,27 @@ repos:
     reposync:
       latest_only: false
 
+  rhel-9-fast-datapath-rpms:
+    conf:
+      baseurl:
+        x86_64: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/x86_64/fast-datapath/os/
+        ppc64le: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/ppc64le/fast-datapath/os/
+        s390x: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/s390x/fast-datapath/os/
+        aarch64: http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel9/aarch64/fast-datapath/os/
+      ci_alignment:
+        profiles:
+        - el9
+        localdev:
+          enabled: true
+    content_set:
+      default: fast-datapath-for-rhel-9-x86_64-rpms
+      aarch64: fast-datapath-for-rhel-9-aarch64-rpms
+      ppc64le: fast-datapath-for-rhel-9-ppc64le-rpms
+      s390x: fast-datapath-for-rhel-9-s390x-rpms
+      optional: true
+    reposync:
+      enabled: true
+
 default_image_build_method: osbs2
 image_build_log_scanner:
   matches:


### PR DESCRIPTION
ref [slack](https://redhat-internal.slack.com/archives/CB95J6R4N/p1673546271966089?thread_ts=1673543198.918899&cid=CB95J6R4N)