### PR TITLE
OSDOC-4282:updates the 4.12 branch stock errata text

### DIFF
--- a/erratatool.yml
+++ b/erratatool.yml
@@ -36,12 +36,13 @@ description: |
 
   This advisory contains the RPM packages / container images for Red Hat OpenShift Container Platform 4.12.z. See the following advisory for the container images / RPM packages for this release:
 
-  <ADVISORY_URL> e.g. https://access.redhat.com/errata/RHBA-2022:1234
+  <ADVISORY_URL> e.g. https://access.redhat.com/errata/RHBA-2023:1234
 
   Space precludes documenting all of the bug fixes and enhancements in this advisory, as well as all of the container images in this advisory. See the following Release Notes documentation, which will be updated shortly for this release, for details about these changes:
 
   https://docs.openshift.com/container-platform/4.12/release_notes/ocp-4-12-release-notes.html
 
+  All OpenShift Container Platform 4.12 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift CLI (oc) or web console. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.12/updating/updating-cluster-cli.html
 
 solution: |
   For OpenShift Container Platform 4.12 see the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
@@ -64,7 +65,7 @@ solution: |
   (For aarch64 architecture)
   The image digest is sha256:<SHASUM_HERE>
 
-  All OpenShift Container Platform 4.12 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.12/updating/updating-cluster-cli.html
+  All OpenShift Container Platform 4.12 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift CLI (oc) or web console. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.12/updating/updating-cluster-cli.html
 
 topic: "Red Hat OpenShift Container Platform release 4.12.z is now available with updates to packages and images that fix several bugs and add enhancements."
 
@@ -79,9 +80,9 @@ boilerplates:
 
       This advisory contains the RPM packages for Red Hat OpenShift Container Platform 4.12.z. See the following advisory for the container images for this release:
 
-      <ADVISORY_URL> e.g. https://access.redhat.com/errata/RHBA-2022:1234
+      <ADVISORY_URL> e.g. https://access.redhat.com/errata/RHBA-2023:1234
 
-      All OpenShift Container Platform 4.12 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.12/updating/updating-cluster-cli.html
+      All OpenShift Container Platform 4.12 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift CLI (oc) or web console. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.12/updating/updating-cluster-cli.html
     solution: &common_solution |
       See the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
 
@@ -96,34 +97,44 @@ boilerplates:
 
       This advisory contains the container images for Red Hat OpenShift Container Platform 4.12.z. See the following advisory for the RPM packages for this release:
 
-      <ADVISORY_URL> e.g. https://access.redhat.com/errata/RHBA-2022:1234
+      <ADVISORY_URL> e.g. https://access.redhat.com/errata/RHBA-2023:1234
 
       Space precludes documenting all of the container images in this advisory. See the following Release Notes documentation, which will be updated shortly for this release, for details about these changes:
 
       https://docs.openshift.com/container-platform/4.12/release_notes/ocp-4-12-release-notes.html
 
-    solution: |
-      For OpenShift Container Platform 4.12 see the following documentation, which will be updated shortly for this release, for important instructions on how to upgrade your cluster and fully apply this asynchronous errata update:
+    solution: &common_image_solution |
+       See the following release notes for complete documentation of all bug fixes and enhancements in this advisory. The release notes will be updated shortly for this release.
 
       https://docs.openshift.com/container-platform/4.12/release_notes/ocp-4-12-release-notes.html
 
       You may download the oc tool and use it to inspect release image metadata for x86_64, s390x, ppc64le, and aarch64 architectures. The image digests may be found at https://quay.io/repository/openshift-release-dev/ocp-release?tab=tags
 
-      The sha values for the release are:
-
       (For x86_64 architecture)
+
+        $ oc adm release info quay.io/openshift-release-dev/ocp-release:4.12.z-x86_64
+
       The image digest is sha256:<SHASUM_HERE>
 
       (For s390x architecture)
+
+        $ oc adm release info quay.io/openshift-release-dev/ocp-release:4.12.z-s390x
+
       The image digest is sha256:<SHASUM_HERE>
 
       (For ppc64le architecture)
+
+        $ oc adm release info quay.io/openshift-release-dev/ocp-release:4.12.z-ppc64le
+
       The image digest is sha256:<SHASUM_HERE>
 
       (For aarch64 architecture)
+
+        $ oc adm release info quay.io/openshift-release-dev/ocp-release:4.12.z-aarch64
+
       The image digest is sha256:<SHASUM_HERE>
 
-      All OpenShift Container Platform 4.12 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.12/updating/updating-cluster-cli.html
+      All OpenShift Container Platform 4.12 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift CLI (oc) or web console. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.12/updating/updating-cluster-cli.html
   extras:
     synopsis: OpenShift Container Platform 4.12.z extras update
     topic: *common_topic
@@ -141,7 +152,7 @@ boilerplates:
 
       This advisory will be used to release the corresponding Operator manifests via new Operator metadata containers.
 
-      All OpenShift Container Platform 4.12 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift Console or the CLI oc command. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.12/updating/updating-cluster-cli.html
+      All OpenShift Container Platform 4.12 users are advised to upgrade to these updated packages and images when they are available in the appropriate release channel. To check for available updates, use the OpenShift CLI (oc) or web console. Instructions for upgrading a cluster are available at https://docs.openshift.com/container-platform/4.12/updating/updating-cluster-cli.html
     solution: *common_solution
   cve:
     synopsis: OpenShift Container Platform 4.12.z security update
@@ -158,5 +169,5 @@ boilerplates:
       For more details about the security issue(s), including the impact, a CVSS
       score, acknowledgments, and other related information, refer to the CVE page(s)
       listed in the References section.
-    solution: *common_solution
+    solution: *common_image_solution
     security_reviewer: sfowler@redhat.com


### PR DESCRIPTION
[OSDOCS-4282](https://issues.redhat.com//browse/OSDOCS-4282) updates the stock errata text for the RNs docs team. Updates include 2022 to 2023 and defining a images solution so that both RHBA and RHSA have the SHA values moved from the `description` to the `solution`.

