### PR TITLE
[ART-5758] 4.11 releases.yml: no apparent need to pin rt-setup

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -1119,19 +1119,3 @@ releases:
             container_yaml!: {}
             cachito:
               enabled: true
-  stream:
-    assembly:
-      type: stream
-      permits:
-      - code: OUTDATED_RPMS_IN_STREAM_BUILD
-        component: '*'
-      # why: default permit
-      - code: CONFLICTING_GROUP_RPM_INSTALLED
-        component: 'rhcos'
-      # why: default permit
-      group:
-        dependencies:
-          rpms:
-          - why: See RHELWF-8001 and RHELDST-14877 -- kernel-rt dep from 8.7
-            non_gc_tag: rhel-8.6.0-z
-            el8: rt-setup-2.1-4.el8


### PR DESCRIPTION
I can't see any evidence this is used anywhere or justification why we need it, so let's try removing the cruft.