### PR TITLE
[ART-5755] cloud-event-proxy: correct repo

### DIFF
--- a/images/cloud-event-proxy.yml
+++ b/images/cloud-event-proxy.yml
@@ -23,7 +23,10 @@ from:
   builder:
   - stream: golang
   member: openshift-enterprise-base
-name: openshift/ose-cloud-event-proxy-rhel8
+# note that errata config went to the wrong repo for this at 4.11 and 4.12 GAs, which broke not only
+# the main release but another non-ART component that also depends on it being here. so don't change
+# this, change errata to match this if it is necessary:
+name: openshift/ose-cloud-event-proxy
 name_in_bundle: cloud-event-proxy
 owners:
 - nparekh@redhat.com


### PR DESCRIPTION
note that errata config went to the wrong repo for this at 4.11 and 4.12 GAs, which broke not only
the main release but another non-ART component that also depends on it being at the non-`-rhel8` repo.
