### PR TITLE
rpms/openshift: temp. disable el9

### DIFF
--- a/rpms/openshift.yml
+++ b/rpms/openshift.yml
@@ -15,7 +15,7 @@ owners:
 - aos-master@redhat.com
 targets:
 - rhaos-{MAJOR}.{MINOR}-rhel-8-candidate
-- rhaos-{MAJOR}.{MINOR}-rhel-9-candidate
+# - rhaos-{MAJOR}.{MINOR}-rhel-9-candidate
 hotfix_targets:
 - rhaos-{MAJOR}.{MINOR}-rhel-8-hotfix
-- rhaos-{MAJOR}.{MINOR}-rhel-9-hotfix
+# - rhaos-{MAJOR}.{MINOR}-rhel-9-hotfix


### PR DESCRIPTION
builds are failing only there due to [buildroot problems that have stalled](https://issues.redhat.com/browse/CWFCONF-3271). no point in rebuilding constantly.

ref. [slack thread](https://redhat-internal.slack.com/archives/C048BG69N8H/p1674470895490509?thread_ts=1674461263.464709&cid=C048BG69N8H) and [CWFCONF-3271]( https://issues.redhat.com/browse/CWFCONF-3271) and [CWFCONF-3293](https://issues.redhat.com/browse/CWFCONF-3293)