### PR TITLE
Stop rebuilding el9 openshift-clients

### DIFF
--- a/rpms/openshift-clients.yml
+++ b/rpms/openshift-clients.yml
@@ -10,7 +10,7 @@ owners:
 - aos-master@redhat.com
 targets:
 - rhaos-{MAJOR}.{MINOR}-rhel-8-candidate
-- rhaos-{MAJOR}.{MINOR}-rhel-9-candidate
+# - rhaos-{MAJOR}.{MINOR}-rhel-9-candidate
 hotfix_targets:
 - rhaos-{MAJOR}.{MINOR}-rhel-8-hotfix
-- rhaos-{MAJOR}.{MINOR}-rhel-9-hotfix
+# - rhaos-{MAJOR}.{MINOR}-rhel-9-hotfix


### PR DESCRIPTION
Parallel to https://github.com/openshift/ocp-build-data/pull/2515. Stop building perma-failing el9 of openshift-clients as well to not get enourmous churn in rhcos builds.