### PR TITLE
images: ose-ibmcloud-cluster-api-controllers: add carry commit prefix

### DIFF
--- a/images/ose-ibmcloud-cluster-api-controllers.yml
+++ b/images/ose-ibmcloud-cluster-api-controllers.yml
@@ -12,6 +12,7 @@ content:
       web: https://github.com/openshift/cluster-api-provider-ibmcloud.git
     ci_alignment:
       streams_prs:
+        commit_prefix: "UPSTREAM: <carry>: "
         ci_build_root:
           stream: rhel-8-golang-ci-build-root
 enabled_repos:


### PR DESCRIPTION
This adds the carry prefix to cluster-api-provider-ibmcloud, so than we can use it with the rebase bot.