### PR TITLE
Freeze automation until golang bump

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -1,4 +1,4 @@
-freeze_automation: true
+freeze_automation: weekdays
 
 vars:
   MAJOR: 4

--- a/group.yml
+++ b/group.yml
@@ -1,4 +1,4 @@
-freeze_automation: false
+freeze_automation: true
 
 vars:
   MAJOR: 4


### PR DESCRIPTION
Freeze automation until we can get new golang builders in.
This is important since mass rebuild is being triggered by
rhel update, and we want to wait until we have new golang