### PR TITLE
microshift: Fix build

### DIFF
--- a/modifications/microshift-rebase
+++ b/modifications/microshift-rebase
@@ -27,16 +27,16 @@ fi
 # In the future we might have to run rebase.sh inside of a container to use specific versions of dependencies (including golang).
 export PATH=/opt/go-1.18.7/bin:/opt/yq-go/bin:$PATH
 
-if [ -n "$RELEASE_NAME" ]; then
+if [ -n "$RELEASE_NAME" ] && [ -n "$LVMS_OPERATOR_BUNDLE" ]; then
     # rebase against a named release
-    ./scripts/auto-rebase/rebase.sh to "$RELEASE_REPO":"$RELEASE_NAME"-x86_64 "$RELEASE_REPO":"$RELEASE_NAME"-aarch64
+    ./scripts/auto-rebase/rebase.sh to "$RELEASE_REPO":"$RELEASE_NAME"-x86_64 "$RELEASE_REPO":"$RELEASE_NAME"-aarch64 "$LVMS_OPERATOR_BUNDLE"
     exit 0
 fi
 
-if [ -n "$MICROSHIFT_PAYLOAD_X86_64" ] && [ -n "$MICROSHIFT_PAYLOAD_AARCH64" ]; then
+if [ -n "$MICROSHIFT_PAYLOAD_X86_64" ] && [ -n "$MICROSHIFT_PAYLOAD_AARCH64" ] && [ -n "$LVMS_OPERATOR_BUNDLE" ]; then
     # rebase against specified release payloads
-    ./scripts/auto-rebase/rebase.sh to "$MICROSHIFT_PAYLOAD_X86_64" "$MICROSHIFT_PAYLOAD_AARCH64"
+    ./scripts/auto-rebase/rebase.sh to "$MICROSHIFT_PAYLOAD_X86_64" "$MICROSHIFT_PAYLOAD_AARCH64" "$LVMS_OPERATOR_BUNDLE"
     exit 0
 fi
 
-fail "Environment variable RELEASE_NAME is not set."
+fail "Environment variable RELEASE_NAME or LVMS_OPERATOR_BUNDLE is not set."

--- a/rpms/microshift.yml
+++ b/rpms/microshift.yml
@@ -4,7 +4,7 @@ content:
   source:
     git:
       branch:
-        target: main
+        target: release-4.13
       url: git@github.com:openshift-priv/microshift.git
     specfile: packaging/rpm/microshift.spec
     modifications:
@@ -12,6 +12,10 @@ content:
       command: microshift-rebase
       env:
         RELEASE_NAME: "{release_name}"
+        # Since there's no lvms for 4.13 yet and microshift doesn't require a specific version
+        # of lvms-operator-bundle, hardcode v4.12 for now.
+        # # https://github.com/openshift/microshift/blob/main/docs/rebase.md#getting-release-image-build-references
+        LVMS_OPERATOR_BUNDLE: registry.access.redhat.com/lvms4/lvms-operator-bundle:v4.12
 
 name: microshift
 targets: []


### PR DESCRIPTION
Since there's no lvms for 4.13 yet and microshift doesn't require a specific version of lvms-operator-bundle, hardcode v4.12 for now.

This has been confirmed with microshift team.