### PR TITLE
Microshift-errata:name change to include .z

### DIFF
--- a/erratatool.yml
+++ b/erratatool.yml
@@ -30,6 +30,7 @@ synopsis:
   image: "OpenShift Container Platform 4.12.z images update"
   extras: "OpenShift Container Platform 4.12.z extras update"
   metadata: "OpenShift Container Platform 4.12.z OLM Operators metadata update"
+  microshift: "Red Hat build of MicroShift 4.12.z bug fix and enhancement update"
 
 description: |
   Red Hat OpenShift Container Platform is Red Hat's cloud computing Kubernetes application platform solution designed for on-premise or private cloud deployments.


### PR DESCRIPTION
This update adds the `y` and `z` to MicroShift's rpm advisories. 