### PR TITLE
ART-6050 Add monitoring-plugin to component mapping

### DIFF
--- a/product.yml
+++ b/product.yml
@@ -227,6 +227,8 @@ bug_mapping:
       issue_component: Service Broker
     microshift:
       issue_component: MicroShift
+    monitoring-plugin-container:
+      issue_component: Observability UI
     multus-cni-container:
       issue_component: Networking / multus
     mysql-apb-role:


### PR DESCRIPTION
Is the image name I've used here (`monitoring-plugin-container`) in the correct format?

The image repository is https://github.com/openshift/monitoring-plugin