### PR TITLE
Revert "4.13: Pin cno to get nightly"

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -168,10 +168,3 @@ releases:
         component: 'rhcos'
       - code: OUTDATED_RPMS_IN_STREAM_BUILD
         component: '*'
-      members:
-        images:
-        - distgit_key: cluster-network-operator
-          why: Image references broke in recent commit, pinning to last good build
-          metadata:
-            is:
-              nvr: cluster-network-operator-container-v4.13.0-202302231816.p0.g4d5a093.assembly.stream


### PR DESCRIPTION
Reverts openshift/ocp-build-data#2607

See: https://redhat-internal.slack.com/archives/C01CQA76KMX/p1677240323859199

Can merge once cluster-network-operator has image-references matching production build config.