### PR TITLE
update rcm url

### DIFF
--- a/group.yml
+++ b/group.yml
@@ -128,8 +128,8 @@ repos:
   rhel-server-ose-rpms:
     conf:
       baseurl:
-        ppc64le: https://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}/building/ppc64le/os
-        x86_64: https://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}/building/x86_64/os
+        ppc64le: https://download.eng.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}/building/ppc64le/os
+        x86_64: https://download.eng.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}/building/x86_64/os
     content_set:
       default: rhel-7-server-ose-{MAJOR}.{MINOR}-rpms
       optional: true
@@ -137,8 +137,8 @@ repos:
   rhel-server-ose-rpms-embargoed:
     conf:
       baseurl:
-        ppc64le: https://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}/building-embargoed/ppc64le/os
-        x86_64: https://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}/building-embargoed/x86_64/os
+        ppc64le: https://download.eng.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}/building-embargoed/ppc64le/os
+        x86_64: https://download.eng.bos.redhat.com/rcm-guest/puddles/RHAOS/plashets/{MAJOR}.{MINOR}/building-embargoed/x86_64/os
     content_set:
       default: rhel-7-server-ose-{MAJOR}.{MINOR}-rpms
       optional: true


### PR DESCRIPTION
on https://download.lab.bos.redhat.com/ certificate is invalid