### PR TITLE
More product mappings

### DIFF
--- a/product.yml
+++ b/product.yml
@@ -377,6 +377,8 @@ bug_mapping:
       issue_component: Cloud Compute / Other Provider
     ose-aws-cloud-controller-manager-container:
       issue_component: Cloud Compute / Cloud Controller Manager
+    ose-aws-cluster-api-controllers-container:
+      issue_component: Cloud Compute / Other Provider
     ose-aws-ebs-csi-driver-container:
       issue_component: Storage
     ose-aws-ebs-csi-driver-operator-container:
@@ -447,6 +449,8 @@ bug_mapping:
       issue_component: Networking / router
     ose-cluster-kube-apiserver-operator-container:
       issue_component: kube-apiserver
+    ose-cluster-kube-cluster-api-operator-container:
+      issue_component: Cloud Compute / Other Provider
     ose-cluster-kube-controller-manager-operator-container:
       issue_component: kube-controller-manager
     ose-cluster-kube-descheduler-operator-container:
@@ -689,6 +693,8 @@ bug_mapping:
       issue_component: Storage / Operators
     ose-vsphere-cloud-controller-manager-container:
       issue_component: Cloud Compute / Cloud Controller Manager
+    ose-vsphere-cluster-api-controllers-container:
+      issue_component: Cloud Compute / Other Provider
     ose-vsphere-problem-detector-container:
       issue_component: Storage / Operators
     ostree:


### PR DESCRIPTION
I have manually routed these in the past.  You can check the following to confirm the correct component was selected previously:

ose-aws-cluster-api-controllers-container:
https://issues.redhat.com/browse/OCPBUGS-6354

ose-vsphere-cluster-api-controllers-container:
https://issues.redhat.com/browse/OCPBUGS-6354

ose-cluster-kube-cluster-api-operator-container:
https://issues.redhat.com/browse/OCPBUGS-6386