### PR TITLE
Update jira component for samples and insights operator

### DIFF
--- a/product.yml
+++ b/product.yml
@@ -474,7 +474,7 @@ bug_mapping:
     ose-cluster-policy-controller-container:
       issue_component: kube-controller-manager
     ose-cluster-samples-operator-container:
-      issue_component: Samples
+      issue_component: Samples Operator
     ose-cluster-storage-operator-container:
       issue_component: Storage
     ose-cluster-svcat-apiserver-operator-container:
@@ -552,7 +552,7 @@ bug_mapping:
     ose-image-customization-controller-container:
       issue_component: Bare Metal Hardware Provisioning / OS Image Provider
     ose-insights-operator-container:
-      issue_component: Insights operator
+      issue_component: Insights Operator
     ose-installer-artifacts-container:
       issue_component: Installer / openshift-installer
     ose-installer-container:


### PR DESCRIPTION
Both "Samples" and "Insights operator" do not exist as valid component names in OCPBUGS.